### PR TITLE
Add last run to cron timing logic

### DIFF
--- a/cron/cron_test.go
+++ b/cron/cron_test.go
@@ -32,7 +32,7 @@ func TestStopCausesJobsToNotRun(t *testing.T) {
 	cron := New()
 	cron.Start()
 	cron.Stop()
-	cron.AddFunc("* * * * * ?", func() { wg.Done() })
+	cron.AddFunc("* * * * * ?", func() { wg.Done() }, time.Now().Local())
 
 	select {
 	case <-time.After(ONE_SECOND):
@@ -48,7 +48,7 @@ func TestAddBeforeRunning(t *testing.T) {
 	wg.Add(1)
 
 	cron := New()
-	cron.AddFunc("* * * * * ?", func() { wg.Done() })
+	cron.AddFunc("* * * * * ?", func() { wg.Done() }, time.Now().Local())
 	cron.Start()
 	defer cron.Stop()
 
@@ -68,7 +68,7 @@ func TestAddWhileRunning(t *testing.T) {
 	cron := New()
 	cron.Start()
 	defer cron.Stop()
-	cron.AddFunc("* * * * * ?", func() { wg.Done() })
+	cron.AddFunc("* * * * * ?", func() { wg.Done() }, time.Now().Local())
 
 	select {
 	case <-time.After(ONE_SECOND):
@@ -83,7 +83,7 @@ func TestSnapshotEntries(t *testing.T) {
 	wg.Add(1)
 
 	cron := New()
-	cron.AddFunc("@every 2s", func() { wg.Done() })
+	cron.AddFunc("@every 2s", func() { wg.Done() }, time.Now().Local())
 	cron.Start()
 	defer cron.Stop()
 
@@ -111,10 +111,10 @@ func TestMultipleEntries(t *testing.T) {
 	wg.Add(2)
 
 	cron := New()
-	cron.AddFunc("0 0 0 1 1 ?", func() {})
-	cron.AddFunc("* * * * * ?", func() { wg.Done() })
-	cron.AddFunc("0 0 0 31 12 ?", func() {})
-	cron.AddFunc("* * * * * ?", func() { wg.Done() })
+	cron.AddFunc("0 0 0 1 1 ?", func() {}, time.Now().Local())
+	cron.AddFunc("* * * * * ?", func() { wg.Done() }, time.Now().Local())
+	cron.AddFunc("0 0 0 31 12 ?", func() {}, time.Now().Local())
+	cron.AddFunc("* * * * * ?", func() { wg.Done() }, time.Now().Local())
 
 	cron.Start()
 	defer cron.Stop()
@@ -132,9 +132,9 @@ func TestRunningJobTwice(t *testing.T) {
 	wg.Add(2)
 
 	cron := New()
-	cron.AddFunc("0 0 0 1 1 ?", func() {})
-	cron.AddFunc("0 0 0 31 12 ?", func() {})
-	cron.AddFunc("* * * * * ?", func() { wg.Done() })
+	cron.AddFunc("0 0 0 1 1 ?", func() {}, time.Now().Local())
+	cron.AddFunc("0 0 0 31 12 ?", func() {}, time.Now().Local())
+	cron.AddFunc("* * * * * ?", func() { wg.Done() }, time.Now().Local())
 
 	cron.Start()
 	defer cron.Stop()
@@ -151,12 +151,12 @@ func TestRunningMultipleSchedules(t *testing.T) {
 	wg.Add(2)
 
 	cron := New()
-	cron.AddFunc("0 0 0 1 1 ?", func() {})
-	cron.AddFunc("0 0 0 31 12 ?", func() {})
-	cron.AddFunc("* * * * * ?", func() { wg.Done() })
-	cron.Schedule(Every(time.Minute), FuncJob(func() {}))
-	cron.Schedule(Every(time.Second), FuncJob(func() { wg.Done() }))
-	cron.Schedule(Every(time.Hour), FuncJob(func() {}))
+	cron.AddFunc("0 0 0 1 1 ?", func() {}, time.Now().Local())
+	cron.AddFunc("0 0 0 31 12 ?", func() {}, time.Now().Local())
+	cron.AddFunc("* * * * * ?", func() { wg.Done() }, time.Now().Local())
+	cron.Schedule(Every(time.Minute), FuncJob(func() {}), time.Now().Local())
+	cron.Schedule(Every(time.Second), FuncJob(func() { wg.Done() }), time.Now().Local())
+	cron.Schedule(Every(time.Hour), FuncJob(func() {}), time.Now().Local())
 
 	cron.Start()
 	defer cron.Stop()
@@ -178,7 +178,7 @@ func TestLocalTimezone(t *testing.T) {
 		now.Second()+1, now.Minute(), now.Hour(), now.Day(), now.Month())
 
 	cron := New()
-	cron.AddFunc(spec, func() { wg.Done() })
+	cron.AddFunc(spec, func() { wg.Done() }, time.Now().Local())
 	cron.Start()
 	defer cron.Stop()
 
@@ -204,12 +204,12 @@ func TestJob(t *testing.T) {
 	wg.Add(1)
 
 	cron := New()
-	cron.AddJob("0 0 0 30 Feb ?", testJob{wg, "job0"})
-	cron.AddJob("0 0 0 1 1 ?", testJob{wg, "job1"})
-	cron.AddJob("* * * * * ?", testJob{wg, "job2"})
-	cron.AddJob("1 0 0 1 1 ?", testJob{wg, "job3"})
-	cron.Schedule(Every(5*time.Second+5*time.Nanosecond), testJob{wg, "job4"})
-	cron.Schedule(Every(5*time.Minute), testJob{wg, "job5"})
+	cron.AddJob("0 0 0 30 Feb ?", testJob{wg, "job0"}, time.Now().Local())
+	cron.AddJob("0 0 0 1 1 ?", testJob{wg, "job1"}, time.Now().Local())
+	cron.AddJob("* * * * * ?", testJob{wg, "job2"}, time.Now().Local())
+	cron.AddJob("1 0 0 1 1 ?", testJob{wg, "job3"}, time.Now().Local())
+	cron.Schedule(Every(5*time.Second+5*time.Nanosecond), testJob{wg, "job4"}, time.Now().Local())
+	cron.Schedule(Every(5*time.Minute), testJob{wg, "job5"}, time.Now().Local())
 
 	cron.Start()
 	defer cron.Stop()
@@ -252,4 +252,24 @@ func stop(cron *Cron) chan bool {
 		ch <- true
 	}()
 	return ch
+}
+
+// Test running a job that missed the last execution starts immediately.
+func TestJobMissedLastExecution(t *testing.T) {
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	cron := New()
+	thePast := time.Now().Add(-10 * time.Second)
+	fmt.Println(thePast)
+	cron.Schedule(Every(5*time.Second), testJob{wg, "job4"}, thePast)
+
+	cron.Start()
+	defer cron.Stop()
+
+	select {
+	case <-time.After(1 * ONE_SECOND):
+		t.FailNow()
+	case <-wait(wg):
+	}
 }


### PR DESCRIPTION
Previously, if dkron was down during the window that a job should run
and then started back up, the job would be scheduled at the next
interval or schedule from that point as if the job had just run.

This changes that functionality to schedule jobs based on their
last run time instead of the current time so that on startup,
missed jobs will run.