### PR TITLE
Fix dependent job updates in parent jobs on change or delete (v2.x)

### DIFF
--- a/dkron/store.go
+++ b/dkron/store.go
@@ -133,57 +133,70 @@ func (s *Store) SetJob(job *Job, copyDependentJobs bool) error {
 			return err
 		}
 
-		if ej != nil {
-			// Existing job that doesn't have parent job set and it's being set
-			if ej.ParentJob == "" && job.ParentJob != "" {
-				pj, err := job.GetParent()
-				if err != nil {
-					return err
-				}
-
-				pj.DependentJobs = append(pj.DependentJobs, job.Name)
-				if err := s.SetJob(pj, false); err != nil {
-					return err
-				}
-			}
-
-			// Existing job that has parent job set and it's being removed
-			if ej.ParentJob != "" && job.ParentJob == "" {
-				pj, err := ej.GetParent()
-				if err != nil {
-					return err
-				}
-
-				ndx := 0
-				for i, djn := range pj.DependentJobs {
-					if djn == job.Name {
-						ndx = i
-						break
-					}
-				}
-				pj.DependentJobs = append(pj.DependentJobs[:ndx], pj.DependentJobs[ndx+1:]...)
-				if err := s.SetJob(pj, false); err != nil {
-					return err
-				}
-			}
-		}
-
-		// New job that has parent job set
-		if ej == nil && job.ParentJob != "" {
-			pj, err := job.GetParent()
-			if err != nil {
+		// If the parent job changed or a new job is created and has a parent,
+		// update the parents of the old (if any) and new jobs
+		if (ej == nil && job.ParentJob != "") || (ej != nil && job.ParentJob != ej.ParentJob) {
+			if err := s.removeFromParent(ej); err != nil {
 				return err
 			}
-
-			pj.DependentJobs = append(pj.DependentJobs, job.Name)
-			if err := s.SetJob(pj, false); err != nil {
+			if err := s.addToParent(job); err != nil {
 				return err
 			}
 		}
+
 		return nil
 	})
 
 	return err
+}
+
+// Removes the given job from its parent.
+// Does nothing if nil is passed as child.
+func (s *Store) removeFromParent(child *Job) error {
+	// Do nothing if no job was given or job has no parent
+	if child == nil || child.ParentJob == "" {
+		return nil
+	}
+
+	parent, err := child.GetParent()
+	if err != nil {
+		return err
+	}
+
+	// Remove all occurrences from the parent, not just one.
+	// Due to an old bug (in v1), a parent can have the same child more than once.
+	djs := []string{}
+	for _, djn := range parent.DependentJobs {
+		if djn != child.Name {
+			djs = append(djs, djn)
+		}
+	}
+	parent.DependentJobs = djs
+	if err := s.SetJob(parent, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Adds the given job to its parent.
+func (s *Store) addToParent(child *Job) error {
+	// Do nothing if job has no parent
+	if child.ParentJob == "" {
+		return nil
+	}
+
+	parent, err := child.GetParent()
+	if err != nil {
+		return err
+	}
+
+	parent.DependentJobs = append(parent.DependentJobs, child.Name)
+	if err := s.SetJob(parent, false); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (s *Store) validateTimeZone(timezone string) error {
@@ -363,6 +376,12 @@ func (s *Store) DeleteJob(name string) (*Job, error) {
 			return err
 		}
 		job = j
+
+		if j.ParentJob != "" {
+			if err := s.removeFromParent(j); err != nil {
+				return err
+			}
+		}
 
 		if err := s.DeleteExecutions(name); err != nil {
 			if err != nil {

--- a/dkron/store_test.go
+++ b/dkron/store_test.go
@@ -81,6 +81,79 @@ func TestStore(t *testing.T) {
 	}
 }
 
+func TestStore_AddDependentJobToParent(t *testing.T) {
+	s, dir := setupStore(t)
+	defer cleanupStore(dir, s)
+
+	storeJob(t, s, "parent1")
+	storeChildJob(t, s, "child1", "parent1")
+	parent := loadJob(t, s, "parent1")
+
+	assert.Equal(t, "child1", parent.DependentJobs[0])
+}
+
+func TestStore_ParentIsUpdatedAfterDeletingDependentJob(t *testing.T) {
+	s, dir := setupStore(t)
+	defer cleanupStore(dir, s)
+
+	storeJob(t, s, "parent1")
+	storeChildJob(t, s, "child1", "parent1")
+	parent := loadJob(t, s, "parent1")
+
+	assert.Equal(t, "child1", parent.DependentJobs[0])
+
+	deleteJob(t, s, "child1")
+	parent = loadJob(t, s, "parent1")
+
+	// Child has to have been removed from the parent (nr. of dependent jobs is 0)
+	assert.Equal(t, 0, len(parent.DependentJobs))
+}
+
+func TestStore_DependentJobsUpdatedAfterSwappingParent(t *testing.T) {
+	s, dir := setupStore(t)
+	defer cleanupStore(dir, s)
+
+	storeJob(t, s, "parent1")
+	storeChildJob(t, s, "child1", "parent1")
+	parent1 := loadJob(t, s, "parent1")
+
+	assert.Equal(t, parent1.DependentJobs[0], "child1")
+
+	storeJob(t, s, "parent2")
+	storeChildJob(t, s, "child1", "parent2")
+	parent1 = loadJob(t, s, "parent1")
+
+	assert.Equal(t, 0, len(parent1.DependentJobs))
+
+	parent2 := loadJob(t, s, "parent2")
+
+	assert.Equal(t, "child1", parent2.DependentJobs[0])
+}
+
+func TestStore_JobBecomesDependentJob(t *testing.T) {
+	s, dir := setupStore(t)
+	defer cleanupStore(dir, s)
+
+	storeJob(t, s, "child1")
+	storeJob(t, s, "parent1")
+	storeChildJob(t, s, "child1", "parent1")
+	parent := loadJob(t, s, "parent1")
+
+	assert.Equal(t, "child1", parent.DependentJobs[0])
+}
+
+func TestStore_JobBecomesIndependentJob(t *testing.T) {
+	s, dir := setupStore(t)
+	defer cleanupStore(dir, s)
+
+	storeJob(t, s, "parent1")
+	storeChildJob(t, s, "child1", "parent1")
+	storeJob(t, s, "child1")
+	parent := loadJob(t, s, "parent1")
+
+	assert.Equal(t, 0, len(parent.DependentJobs))
+}
+
 func TestStore_GetLastExecutionGroup(t *testing.T) {
 	// This can not use time.Now() because that will include monotonic information
 	// that will cause the unmarshalled execution to differ from our generated version
@@ -215,4 +288,57 @@ func TestStore_GetLastExecutionGroup(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// Following are supporting functions for the tests
+
+func storeJob(t *testing.T, s *Store, jobName string) {
+	job := scaffoldJob()
+	job.Name = jobName
+	require.NoError(t, s.SetJob(job, false))
+}
+
+func storeChildJob(t *testing.T, s *Store, jobName string, parentName string) {
+	job := scaffoldJob()
+	job.Name = jobName
+	job.ParentJob = parentName
+	require.NoError(t, s.SetJob(job, false))
+}
+
+func scaffoldJob() *Job {
+	return &Job{
+		Name:           "test",
+		Schedule:       "@every 1m",
+		Executor:       "shell",
+		ExecutorConfig: map[string]string{"command": "/bin/false"},
+		Disabled:       true,
+	}
+}
+
+func setupStore(t *testing.T) (*Store, string) {
+	dir, err := ioutil.TempDir("", "dkron-test")
+	require.NoError(t, err)
+
+	a := NewAgent(nil, nil)
+	s, err := NewStore(a, dir)
+	require.NoError(t, err)
+	a.Store = s
+
+	return s, dir
+}
+
+func cleanupStore(dir string, s *Store) {
+	s.Shutdown()
+	os.RemoveAll(dir)
+}
+
+func loadJob(t *testing.T, s *Store, name string) *Job {
+	job, err := s.GetJob(name, nil)
+	require.NoError(t, err)
+	return job
+}
+
+func deleteJob(t *testing.T, s *Store, name string) {
+	_, err := s.DeleteJob(name)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Fixes #499, superseeds #558 .
