### PR TITLE
V2.x support

### DIFF
--- a/dkron/scheduler.go
+++ b/dkron/scheduler.go
@@ -43,8 +43,8 @@ func NewScheduler() *Scheduler {
 	return &Scheduler{Cron: c, Started: false}
 }
 
-// Start thee cron scheduler adding it's corresponding jobs and
-// executiong them on time.
+// Start the cron scheduler, adding its corresponding jobs and
+// executing them on time.
 func (s *Scheduler) Start(jobs []*Job) {
 	metrics.IncrCounter([]string{"scheduler", "start"}, 1)
 	for _, job := range jobs {
@@ -71,7 +71,7 @@ func (s *Scheduler) Start(jobs []*Job) {
 	schedulerStarted.Set(1)
 }
 
-// Stop stop the scheduler efectively not running any job.
+// Stop stops the scheduler effectively not running any job.
 func (s *Scheduler) Stop() {
 	if s.Started {
 		log.Debug("scheduler: Stopping scheduler")
@@ -87,7 +87,7 @@ func (s *Scheduler) Stop() {
 	schedulerStarted.Set(0)
 }
 
-// Restart thee scheduler
+// Restart the scheduler
 func (s *Scheduler) Restart(jobs []*Job) {
 	s.Stop()
 	s.Start(jobs)

--- a/dkron/store.go
+++ b/dkron/store.go
@@ -150,7 +150,9 @@ func (s *Store) SetJob(job *Job, copyDependentJobs bool) error {
 			if len(ej.DependentJobs) != 0 && copyDependentJobs {
 				job.DependentJobs = ej.DependentJobs
 			}
-		} else {
+		}
+
+		if job.Schedule != ej.Schedule {
 			job.Next, err = job.GetNext()
 			if err != nil {
 				return err

--- a/dkron/store.go
+++ b/dkron/store.go
@@ -309,22 +309,13 @@ func (s *Store) jobHasMetadata(job *Job, metadata map[string]string) bool {
 		return false
 	}
 
-	res := true
 	for k, v := range metadata {
-		var found bool
-
-		if val, ok := job.Metadata[k]; ok && v == val {
-			found = true
-		}
-
-		res = res && found
-
-		if !res {
-			break
+		if val, ok := job.Metadata[k]; !ok || v != val {
+			return false
 		}
 	}
 
-	return res
+	return true
 }
 
 // GetJobs returns all jobs

--- a/ntime/nullabletime.go
+++ b/ntime/nullabletime.go
@@ -1,6 +1,7 @@
 package ntime
 
 import (
+	"bytes"
 	"encoding/json"
 	"time"
 )
@@ -51,11 +52,23 @@ func (t *NullableTime) After(u NullableTime) bool {
 	return t.time.After(u.time)
 }
 
-// MarshalJSON serializer this struct to JSON
+// MarshalJSON serializes this struct to JSON
 // Implements json.Marshaler interface
 func (t *NullableTime) MarshalJSON() ([]byte, error) {
 	if t.hasValue {
 		return json.Marshal(t.time)
 	}
 	return json.Marshal(nil)
+}
+
+// UnmarshalJSON deserializes JSON into this struct
+// Implements json.Unmarshaler interface
+func (t *NullableTime) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(data, []byte("null")) {
+		t.hasValue = false
+		return nil
+	}
+
+	t.hasValue = true
+	return json.Unmarshal(data, &t.time)
 }


### PR DESCRIPTION
This PR has several changes:
- Fixes the unmarshaling error mentioned in #579, introduced in c7d65fc .
- Improves the fix for #587 so when a job's schedule changes, the next execution time also gets updated
- Textual improves to some comments in scheduler.go
- Simplification of code in `jobHasMetadata(...)` with addition of a test to make sure behavior did not change.