### PR TITLE
Autorun job after create

### DIFF
--- a/cron/parser.go
+++ b/cron/parser.go
@@ -225,6 +225,9 @@ func parseDescriptor(spec string) Schedule {
 			Month:  all(months),
 			Dow:    all(dow),
 		}
+
+	case "@manually":
+		return At(time.Time{})
 	}
 
 	const every = "@every "

--- a/dkron/api.go
+++ b/dkron/api.go
@@ -165,6 +165,11 @@ func (h *HTTPTransport) jobCreateOrUpdateHandler(c *gin.Context) {
 		return
 	}
 
+	// Immediately run the job if so requested
+	if _, exists := c.GetQuery("runoncreate"); exists {
+		h.agent.GRPCClient.RunJob(job.Name)
+	}
+
 	c.Header("Location", fmt.Sprintf("%s/%s", c.Request.RequestURI, job.Name))
 	renderJSON(c, http.StatusCreated, &job)
 }

--- a/website/content/swagger.yaml
+++ b/website/content/swagger.yaml
@@ -65,6 +65,13 @@ paths:
           required: true
           schema:
             $ref: "#/definitions/job"
+        - in: query
+          name: runoncreate
+          description: If present, regardless of any value, causes the job to be run immediately after being succesfully created or updated.
+          required: false
+          schema:
+            type: boolean
+          allowEmptyValue: true
       responses:
         201:
           description: Successful response

--- a/website/content/usage/cron-spec.md
+++ b/website/content/usage/cron-spec.md
@@ -63,6 +63,7 @@ You may use one of several pre-defined schedules in place of a cron expression.
 	@daily (or @midnight)  | Run once a day, midnight                   | 0 0 0 * * *
 	@hourly                | Run once an hour, beginning of hour        | 0 0 * * * *
 	@minutely              | Run once a minute, beginning of minute     | 0 * * * * *
+	@manually              | Never runs                                 | N/A
 
 ### Intervals
 


### PR DESCRIPTION
This PR is how I imagine the implementation of a feature allowing a job that gets run when it gets created.

It introduces a `runoncreate` querystring parameter for the create/update API call, and the `@manually` predefined schedule.

Together these allow dkron to be used kind of like a task queue, as discussed in #578. The main difference with an actual task queue is that dkron has no throttling mechanism and would just run tasks as they are created. Dkron does not scale in this regard, so if too many requests are sent, it might drown in jobs. Use with care.

To use:
```
url -X POST -v -o - -d '{
  "name": "job1",
  "schedule": "@manually",
  "executor": "shell",
  "executor_config": {
    "command": "echo Hello world"
  }
}' 'localhost:8080/v1/jobs?runoncreate'
```