### PR TITLE
Improve validation of job values, return 4xx error when validation fails

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -850,7 +850,7 @@ func (a *Agent) RefreshJobStatus(jobName string) {
 }
 
 // applySetJob is a helper method to be called when
-// a job property need to be modifeid from the leader.
+// a job property need to be modified from the leader.
 func (a *Agent) applySetJob(job *proto.Job) error {
 	cmd, err := Encode(SetJobType, job)
 	if err != nil {

--- a/dkron/job.go
+++ b/dkron/job.go
@@ -44,7 +44,7 @@ var (
 	// ErrNoCommand is returned when attempting to store a job that has no command.
 	ErrNoCommand = errors.New("Unspecified command for job")
 	// ErrWrongConcurrency is returned when Concurrency is set to a non existing setting.
-	ErrWrongConcurrency = errors.New("Wrong concurrency policy value, use: allow/forbid")
+	ErrWrongConcurrency = errors.New("invalid concurrency policy value, use \"allow\" or \"forbid\"")
 )
 
 // Job descibes a scheduled Job.


### PR DESCRIPTION
This especially prevents jobs with an invalid schedule from getting stored.
E.g. a schedule of `@at notatime` is now rejected, instead of stored and afterwards ignored by the scheduler.

Concurrency is also validated, but that is a user courtesy, not a technical necessity.