### PR TITLE
Peer refactor

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -54,6 +54,10 @@ type Agent struct {
 	GRPCClient       DkronGRPCClient
 	TLSConfig        *tls.Config
 
+	// Pro features
+	GlobalLock         bool
+	MemberEventHandler func(serf.Event)
+
 	serf        *serf.Serf
 	config      *Config
 	eventCh     chan serf.Event
@@ -80,8 +84,8 @@ type Agent struct {
 
 	// peers is used to track the known Dkron servers. This is
 	// used for region forwarding and clustering.
-	peers      map[string][]*serverParts
-	localPeers map[raft.ServerAddress]*serverParts
+	peers      map[string][]*ServerParts
+	localPeers map[raft.ServerAddress]*ServerParts
 	peerLock   sync.RWMutex
 }
 
@@ -317,8 +321,8 @@ func (a *Agent) setupSerf() (*serf.Serf, error) {
 	config := a.config
 
 	// Init peer list
-	a.localPeers = make(map[raft.ServerAddress]*serverParts)
-	a.peers = make(map[string][]*serverParts)
+	a.localPeers = make(map[raft.ServerAddress]*ServerParts)
+	a.peers = make(map[string][]*ServerParts)
 
 	bindIP, bindPort, err := config.AddrParts(config.BindAddr)
 	if err != nil {
@@ -535,7 +539,7 @@ func (a *Agent) IsLeader() bool {
 }
 
 // ListServers returns the list of server members
-func (a *Agent) ListServers() (members []*serverParts) {
+func (a *Agent) ListServers() (members []*ServerParts) {
 	for _, member := range a.serf.Members() {
 		ok, parts := isServer(member)
 		if !ok || member.Status != serf.StatusAlive {
@@ -548,18 +552,14 @@ func (a *Agent) ListServers() (members []*serverParts) {
 	return members
 }
 
+// GetPeers returns a list of the current serf servers peers addresses
+func (a *Agent) GetPeers() map[raft.ServerAddress]*ServerParts {
+	return a.localPeers
+}
+
 // LocalMember return the local serf member
 func (a *Agent) LocalMember() serf.Member {
 	return a.serf.LocalMember()
-}
-
-// GetPeers returns a list of the current serf servers peers addresses
-func (a *Agent) GetPeers() (peers []string) {
-	ps := a.ListServers()
-	for _, p := range ps {
-		peers = append(peers, p.RPCAddr.String())
-	}
-	return
 }
 
 // Listens to events from Serf and handle the event.
@@ -580,6 +580,10 @@ func (a *Agent) eventLoop() {
 						"member": member.Name,
 						"event":  e.EventType(),
 					}).Debug("agent: Member event")
+				}
+
+				if a.MemberEventHandler != nil {
+					a.MemberEventHandler(e)
 				}
 
 				// serfEventHandler is used to handle events from the serf cluster

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -538,8 +538,30 @@ func (a *Agent) IsLeader() bool {
 	return a.raft.State() == raft.Leader
 }
 
-// ListServers returns the list of server members
-func (a *Agent) ListServers() (members []*ServerParts) {
+// Members is used to return the members of the serf cluster
+func (a *Agent) Members() []serf.Member {
+	return a.serf.Members()
+}
+
+// LocalMember is used to return the local node
+func (a *Agent) LocalMember() serf.Member {
+	return a.serf.LocalMember()
+}
+
+// Servers returns a list of known server
+func (a *Agent) Servers() (members []*ServerParts) {
+	for _, member := range a.serf.Members() {
+		ok, parts := isServer(member)
+		if !ok || member.Status != serf.StatusAlive {
+			continue
+		}
+		members = append(members, parts)
+	}
+	return members
+}
+
+// LocalServers returns a list of the local known server
+func (a *Agent) LocalServers() (members []*ServerParts) {
 	for _, member := range a.serf.Members() {
 		ok, parts := isServer(member)
 		if !ok || member.Status != serf.StatusAlive {
@@ -550,16 +572,6 @@ func (a *Agent) ListServers() (members []*ServerParts) {
 		}
 	}
 	return members
-}
-
-// GetPeers returns a list of the current serf servers peers addresses
-func (a *Agent) GetPeers() map[raft.ServerAddress]*ServerParts {
-	return a.localPeers
-}
-
-// LocalMember return the local serf member
-func (a *Agent) LocalMember() serf.Member {
-	return a.serf.LocalMember()
 }
 
 // Listens to events from Serf and handle the event.

--- a/dkron/api.go
+++ b/dkron/api.go
@@ -231,8 +231,9 @@ func (h *HTTPTransport) leaderHandler(c *gin.Context) {
 
 func (h *HTTPTransport) leaveHandler(c *gin.Context) {
 	if err := h.agent.Stop(); err != nil {
-		renderJSON(c, http.StatusOK, h.agent.ListServers())
+		c.AbortWithError(http.StatusInternalServerError, err)
 	}
+	renderJSON(c, http.StatusOK, h.agent.peers)
 }
 
 func (h *HTTPTransport) jobToggleHandler(c *gin.Context) {
@@ -249,7 +250,7 @@ func (h *HTTPTransport) jobToggleHandler(c *gin.Context) {
 
 	// Call gRPC SetJob
 	if err := h.agent.GRPCClient.SetJob(job); err != nil {
-		c.AbortWithError(422, err)
+		c.AbortWithError(http.StatusUnprocessableEntity, err)
 		return
 	}
 

--- a/dkron/invoke.go
+++ b/dkron/invoke.go
@@ -78,7 +78,10 @@ func (a *Agent) invokeJob(job *Job, execution *Execution) error {
 // like a cache store.
 func (a *Agent) selectServerByKey(key string) (string, error) {
 	ch := consistenthash.New(50, nil)
-	ch.Add(a.GetPeers()...)
+	for _, p := range a.localPeers {
+		ch.Add(p.RPCAddr.String())
+	}
+
 	peerAddress := ch.Get(key)
 	if peerAddress == "" {
 		return "", ErrNoSuitableServer

--- a/dkron/invoke.go
+++ b/dkron/invoke.go
@@ -78,7 +78,7 @@ func (a *Agent) invokeJob(job *Job, execution *Execution) error {
 // like a cache store.
 func (a *Agent) selectServerByKey(key string) (string, error) {
 	ch := consistenthash.New(50, nil)
-	for _, p := range a.localPeers {
+	for _, p := range a.LocalServers() {
 		ch.Add(p.RPCAddr.String())
 	}
 

--- a/dkron/job.go
+++ b/dkron/job.go
@@ -311,6 +311,10 @@ func (j *Job) GetNext() (time.Time, error) {
 }
 
 func (j *Job) isRunnable() bool {
+	if j.Agent.GlobalLock {
+		return false
+	}
+
 	if j.Concurrency == ConcurrencyForbid {
 		j.Agent.RefreshJobStatus(j.Name)
 	}

--- a/dkron/leader.go
+++ b/dkron/leader.go
@@ -201,7 +201,7 @@ func (a *Agent) revokeLeadership() error {
 }
 
 // addRaftPeer is used to add a new Raft peer when a dkron server joins
-func (a *Agent) addRaftPeer(m serf.Member, parts *serverParts) error {
+func (a *Agent) addRaftPeer(m serf.Member, parts *ServerParts) error {
 	// Check for possibility of multiple bootstrap nodes
 	members := a.serf.Members()
 	if parts.Bootstrap {
@@ -273,7 +273,7 @@ func (a *Agent) addRaftPeer(m serf.Member, parts *serverParts) error {
 
 // removeRaftPeer is used to remove a Raft peer when a dkron server leaves
 // or is reaped
-func (a *Agent) removeRaftPeer(m serf.Member, parts *serverParts) error {
+func (a *Agent) removeRaftPeer(m serf.Member, parts *ServerParts) error {
 	// See if it's already in the configuration. It's harmless to re-remove it
 	// but we want to avoid doing that if possible to prevent useless Raft
 	// log entries.

--- a/dkron/serf.go
+++ b/dkron/serf.go
@@ -81,7 +81,7 @@ func (a *Agent) maybeBootstrap() {
 
 	// Scan for all the known servers
 	members := a.serf.Members()
-	var servers []serverParts
+	var servers []ServerParts
 	voters := 0
 	for _, member := range members {
 		valid, p := isServer(member)

--- a/dkron/utils.go
+++ b/dkron/utils.go
@@ -21,8 +21,8 @@ func (a int64arr) Len() int           { return len(a) }
 func (a int64arr) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a int64arr) Less(i, j int) bool { return a[i] < a[j] }
 
-// serverParts is used to return the parts of a server role
-type serverParts struct {
+// ServerParts is used to return the parts of a server role
+type ServerParts struct {
 	Name         string
 	ID           string
 	Region       string
@@ -37,13 +37,15 @@ type serverParts struct {
 	Status       serf.MemberStatus
 }
 
-func (s *serverParts) String() string {
+// String returns a representation of this instance
+func (s *ServerParts) String() string {
 	return fmt.Sprintf("%s (Addr: %s) (DC: %s)",
 		s.Name, s.Addr, s.Datacenter)
 }
 
-func (s *serverParts) Copy() *serverParts {
-	ns := new(serverParts)
+// Copy returns a copy of this struct
+func (s *ServerParts) Copy() *ServerParts {
+	ns := new(ServerParts)
 	*ns = *s
 	return ns
 }
@@ -53,9 +55,9 @@ func UserAgent() string {
 	return fmt.Sprintf("Dkron/%s (+%s;)", Version, projectURL)
 }
 
-// Returns if a member is a Dkron server. Returns a boolean,
+// IsServer Returns if a member is a Dkron server. Returns a boolean,
 // and a struct with the various important components
-func isServer(m serf.Member) (bool, *serverParts) {
+func isServer(m serf.Member) (bool, *ServerParts) {
 	if m.Tags["role"] != "dkron" {
 		return false, nil
 	}
@@ -102,7 +104,7 @@ func isServer(m serf.Member) (bool, *serverParts) {
 
 	addr := &net.TCPAddr{IP: m.Addr, Port: port}
 	rpcAddr := &net.TCPAddr{IP: rpcIP, Port: port}
-	parts := &serverParts{
+	parts := &ServerParts{
 		Name:         m.Name,
 		ID:           id,
 		Region:       region,

--- a/go.mod
+++ b/go.mod
@@ -55,3 +55,5 @@ require (
 )
 
 replace github.com/hashicorp/mdns => github.com/hashicorp/mdns v1.0.1
+
+go 1.13


### PR DESCRIPTION
* Adding a couple of new getters serf specific and refactor others with better naming.
* Add a couple of Pro needed vars
* ServerParts goes public because it's used in public getters.
* Fix API `leave` method response
* Use Go 1.13