### PR TITLE
Represent execution times in the job's timezone

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -824,7 +824,7 @@ func (a *Agent) getRPCAddr() string {
 func (a *Agent) RefreshJobStatus(jobName string) {
 	var group string
 
-	execs, _ := a.Store.GetLastExecutionGroup(jobName)
+	execs, _ := a.Store.GetLastExecutionGroup(jobName, nil)
 	nodes := []string{}
 
 	unfinishedExecutions := []*Execution{}
@@ -846,7 +846,7 @@ func (a *Agent) RefreshJobStatus(jobName string) {
 		log.WithField("group", group).Debug("agent: Pending execution group")
 	}
 
-	// If there is pending executions to finish ask if they are really pending.
+	// If there are pending executions to finish, ask if they are really pending.
 	if len(nodes) > 0 && group != "" {
 		statuses := a.executionDoneQuery(nodes, group)
 

--- a/dkron/api.go
+++ b/dkron/api.go
@@ -216,7 +216,7 @@ func (h *HTTPTransport) executionsHandler(c *gin.Context) {
 		return
 	}
 
-	executions, err := h.agent.Store.GetExecutions(job.Name)
+	executions, err := h.agent.Store.GetExecutions(job.Name, job.GetTimeLocation())
 	if err != nil {
 		if err == badger.ErrKeyNotFound {
 			renderJSON(c, http.StatusOK, &[]Execution{})

--- a/dkron/dashboard.go
+++ b/dkron/dashboard.go
@@ -89,9 +89,15 @@ func (a *Agent) dashboardJobsHandler(c *gin.Context) {
 }
 
 func (a *Agent) dashboardExecutionsHandler(c *gin.Context) {
-	job := c.Param("job")
+	jobName := c.Param("job")
 
-	groups, byGroup, err := a.Store.GetGroupedExecutions(job)
+	// Get the job's timezone
+	var jobLocation *time.Location
+	if job, err := a.Store.GetJob(jobName, nil); err == nil {
+		jobLocation = job.GetTimeLocation()
+	}
+
+	groups, byGroup, err := a.Store.GetGroupedExecutions(jobName, jobLocation)
 	if err != nil {
 		log.Error(err)
 	}
@@ -110,7 +116,7 @@ func (a *Agent) dashboardExecutionsHandler(c *gin.Context) {
 	}{
 		Common:  newCommonDashboardData(a, a.config.NodeName, "../../../"),
 		Groups:  groups,
-		JobName: job,
+		JobName: jobName,
 		ByGroup: byGroup,
 		Count:   count,
 	}

--- a/dkron/grpc.go
+++ b/dkron/grpc.go
@@ -200,7 +200,7 @@ func (grpcs *GRPCServer) ExecutionDone(ctx context.Context, execDoneReq *proto.E
 		return nil, nil
 	}
 
-	exg, err := grpcs.agent.Store.GetExecutionGroup(&execution)
+	exg, err := grpcs.agent.Store.GetExecutionGroup(&execution, job.GetTimeLocation())
 	if err != nil {
 		log.WithError(err).WithField("group", execution.Group).Error("grpc: Error getting execution group.")
 		return nil, err

--- a/dkron/grpc_test.go
+++ b/dkron/grpc_test.go
@@ -56,7 +56,7 @@ func TestGRPCExecutionDone(t *testing.T) {
 
 	rc := NewGRPCClient(nil, a)
 	rc.ExecutionDone(a.getRPCAddr(), testExecution)
-	execs, _ := a.Store.GetExecutions("test")
+	execs, _ := a.Store.GetExecutions("test", nil)
 
 	assert.Len(t, execs, 1)
 	assert.Equal(t, string(testExecution.Output), string(execs[0].Output))

--- a/dkron/job.go
+++ b/dkron/job.go
@@ -256,7 +256,7 @@ func (j *Job) GetStatus() string {
 		return StatusNotSet
 	}
 
-	execs, _ := j.Agent.Store.GetLastExecutionGroup(j.Name)
+	execs, _ := j.Agent.Store.GetLastExecutionGroup(j.Name, j.GetTimeLocation())
 	success := 0
 	failed := 0
 	for _, ex := range execs {
@@ -310,6 +310,14 @@ func (j *Job) GetParent() (*Job, error) {
 	}
 
 	return parentJob, nil
+}
+
+// GetTimeLocation returns the time.Location based on the job's Timezone,
+// the default (UTC) if none is configured or nil if an error occurred
+// while creating the timezone from the property
+func (j *Job) GetTimeLocation() *time.Location {
+	loc, _ := time.LoadLocation(j.Timezone)
+	return loc
 }
 
 // GetNext returns the job's next schedule from now

--- a/dkron/storage.go
+++ b/dkron/storage.go
@@ -1,6 +1,7 @@
 package dkron
 
 import "io"
+import "time"
 
 // Storage is the interface that should be used by any
 // storage engine implemented for dkron. It contains the
@@ -15,10 +16,10 @@ type Storage interface {
 
 	GetJobs(options *JobOptions) ([]*Job, error)
 	GetJob(name string, options *JobOptions) (*Job, error)
-	GetExecutions(jobName string) ([]*Execution, error)
-	GetLastExecutionGroup(jobName string) ([]*Execution, error)
-	GetExecutionGroup(execution *Execution) ([]*Execution, error)
-	GetGroupedExecutions(jobName string) (map[int64][]*Execution, []int64, error)
+	GetExecutions(jobName string, timezone *time.Location) ([]*Execution, error)
+	GetLastExecutionGroup(jobName string, timezone *time.Location) ([]*Execution, error)
+	GetExecutionGroup(execution *Execution, timezone *time.Location) ([]*Execution, error)
+	GetGroupedExecutions(jobName string, timezone *time.Location) (map[int64][]*Execution, []int64, error)
 	Shutdown() error
 	Snapshot(w io.WriteCloser) error
 	Restore(r io.ReadCloser) error

--- a/dkron/store_test.go
+++ b/dkron/store_test.go
@@ -75,7 +75,7 @@ func TestStore(t *testing.T) {
 	_, err = s.SetExecution(testExecution2)
 	require.NoError(t, err)
 
-	execs, err := s.GetExecutions("test")
+	execs, err := s.GetExecutions("test", nil)
 	assert.NoError(t, err)
 
 	assert.Equal(t, testExecution, execs[0])
@@ -328,7 +328,7 @@ func TestStore_GetLastExecutionGroup(t *testing.T) {
 				s.SetExecution(e)
 			}
 
-			got, err := s.GetLastExecutionGroup(tt.jobName)
+			got, err := s.GetLastExecutionGroup(tt.jobName, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Store.GetLastExecutionGroup() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Implements #526, superseeds #566.