### PR TITLE
refactor: Replace boltdb with fastlog

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -19,10 +19,10 @@ import (
 	"github.com/distribworks/dkron/v2/proto"
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/raft"
-	raftboltdb "github.com/hashicorp/raft-boltdb"
 	"github.com/hashicorp/serf/serf"
 	"github.com/sirupsen/logrus"
 	"github.com/soheilhy/cmux"
+	raftfastlog "github.com/tidwall/raft-fastlog"
 )
 
 const (
@@ -86,7 +86,7 @@ type Agent struct {
 	// raftLayer provides network layering of the raft RPC along with
 	// the Dkron gRPC transport layer.
 	raftLayer     *RaftLayer
-	raftStore     *raftboltdb.BoltStore
+	raftStore     *raftfastlog.FastLogStore
 	raftInmem     *raft.InmemStore
 	raftTransport *raft.NetworkTransport
 
@@ -270,10 +270,9 @@ func (a *Agent) setupRaft() error {
 			return fmt.Errorf("file snapshot store: %s", err)
 		}
 
-		// Create the BoltDB backend
-		s, err := raftboltdb.NewBoltStore(filepath.Join(a.config.DataDir, "raft", "raft.db"))
+		s, err := raftfastlog.NewFastLogStore(filepath.Join(a.config.DataDir, "raft", "raft.db"), raftfastlog.High, log.Writer())
 		if err != nil {
-			return fmt.Errorf("error creating new badger store: %s", err)
+			return fmt.Errorf("error creating new raft log store: %s", err)
 		}
 		a.raftStore = s
 		stableStore = s

--- a/dkron/agent_test.go
+++ b/dkron/agent_test.go
@@ -224,6 +224,7 @@ func TestAgentConfig(t *testing.T) {
 	c.BindAddr = testutil.GetBindAddr().String()
 	c.AdvertiseAddr = advAddr
 	c.LogLevel = logLevel
+	c.DevMode = true
 	c.DataDir = dir
 
 	a := NewAgent(c)

--- a/dkron/invoke_test.go
+++ b/dkron/invoke_test.go
@@ -1,1 +1,0 @@
-package dkron

--- a/dkron/store_test.go
+++ b/dkron/store_test.go
@@ -336,96 +336,91 @@ func TestStore_GetLastExecutionGroup(t *testing.T) {
 }
 
 func Test_computeStatus(t *testing.T) {
-	dir, err := ioutil.TempDir("", "dkron-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	runBadgerTest(t, func(t *testing.T, s *Store) {
+		n := time.Now()
 
-	s, err := NewStore(nil, dir)
-	require.NoError(t, err)
+		// Prepare executions
+		ex1 := &Execution{
+			JobName:    "test",
+			StartedAt:  n,
+			FinishedAt: n,
+			Success:    true,
+			Output:     []byte("type"),
+			NodeName:   "testNode1",
+			Group:      1,
+		}
+		s.SetExecution(ex1)
 
-	n := time.Now()
+		ex2 := &Execution{
+			JobName:    "test",
+			StartedAt:  n.Add(10 * time.Millisecond),
+			FinishedAt: n,
+			Success:    false,
+			Output:     []byte("type"),
+			NodeName:   "testNode2",
+			Group:      1,
+		}
+		s.SetExecution(ex2)
 
-	// Prepare executions
-	ex1 := &Execution{
-		JobName:    "test",
-		StartedAt:  n,
-		FinishedAt: n,
-		Success:    true,
-		Output:     []byte("type"),
-		NodeName:   "testNode1",
-		Group:      1,
-	}
-	s.SetExecution(ex1)
+		ex3 := &Execution{
+			JobName:    "test",
+			StartedAt:  n.Add(20 * time.Millisecond),
+			FinishedAt: n,
+			Success:    true,
+			Output:     []byte("type"),
+			NodeName:   "testNode1",
+			Group:      2,
+		}
+		s.SetExecution(ex3)
 
-	ex2 := &Execution{
-		JobName:    "test",
-		StartedAt:  n.Add(10 * time.Millisecond),
-		FinishedAt: n,
-		Success:    false,
-		Output:     []byte("type"),
-		NodeName:   "testNode2",
-		Group:      1,
-	}
-	s.SetExecution(ex2)
+		ex4 := &Execution{
+			JobName:    "test",
+			StartedAt:  n.Add(30 * time.Millisecond),
+			FinishedAt: n,
+			Success:    true,
+			Output:     []byte("type"),
+			NodeName:   "testNode1",
+			Group:      2,
+		}
+		s.SetExecution(ex4)
 
-	ex3 := &Execution{
-		JobName:    "test",
-		StartedAt:  n.Add(20 * time.Millisecond),
-		FinishedAt: n,
-		Success:    true,
-		Output:     []byte("type"),
-		NodeName:   "testNode1",
-		Group:      2,
-	}
-	s.SetExecution(ex3)
+		ex5 := &Execution{
+			JobName:   "test",
+			StartedAt: n.Add(40 * time.Millisecond),
+			Success:   false,
+			Output:    []byte("type"),
+			NodeName:  "testNode1",
+			Group:     3,
+		}
+		s.SetExecution(ex5)
 
-	ex4 := &Execution{
-		JobName:    "test",
-		StartedAt:  n.Add(30 * time.Millisecond),
-		FinishedAt: n,
-		Success:    true,
-		Output:     []byte("type"),
-		NodeName:   "testNode1",
-		Group:      2,
-	}
-	s.SetExecution(ex4)
+		ex6 := &Execution{
+			JobName:  "test",
+			Success:  false,
+			Output:   []byte("type"),
+			NodeName: "testNode1",
+			Group:    4,
+		}
+		s.SetExecution(ex6)
 
-	ex5 := &Execution{
-		JobName:   "test",
-		StartedAt: n.Add(40 * time.Millisecond),
-		Success:   false,
-		Output:    []byte("type"),
-		NodeName:  "testNode1",
-		Group:     3,
-	}
-	s.SetExecution(ex5)
+		// Tests status
+		err := s.db.View(func(txn *badger.Txn) error {
+			status, _ := s.computeStatus("test", 1, txn)
+			assert.Equal(t, StatusPartialyFailed, status)
 
-	ex6 := &Execution{
-		JobName:  "test",
-		Success:  false,
-		Output:   []byte("type"),
-		NodeName: "testNode1",
-		Group:    4,
-	}
-	s.SetExecution(ex6)
+			status, _ = s.computeStatus("test", 2, txn)
+			assert.Equal(t, StatusSuccess, status)
 
-	// Tests status
-	err = s.db.View(func(txn *badger.Txn) error {
-		status, _ := s.computeStatus("test", 1, txn)
-		assert.Equal(t, StatusPartialyFailed, status)
+			status, _ = s.computeStatus("test", 3, txn)
+			assert.Equal(t, StatusRunning, status)
 
-		status, _ = s.computeStatus("test", 2, txn)
-		assert.Equal(t, StatusSuccess, status)
+			status, _ = s.computeStatus("test", 4, txn)
+			assert.Equal(t, StatusRunning, status)
 
-		status, _ = s.computeStatus("test", 3, txn)
-		assert.Equal(t, StatusRunning, status)
-
-		status, _ = s.computeStatus("test", 4, txn)
-		assert.Equal(t, StatusRunning, status)
-
-		return nil
+			return nil
+		})
+		require.NoError(t, err)
 	})
-	require.NoError(t, err)
 }
 
 // Following are supporting functions for the tests

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.4.0
+	github.com/tidwall/raft-fastlog v0.0.0-20190329194628-f798a12ed2b3
 	github.com/ugorji/go v1.1.5-pre // indirect
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 	golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db // indirect

--- a/go.sum
+++ b/go.sum
@@ -274,6 +274,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tent/http-link-go v0.0.0-20130702225549-ac974c61c2f9 h1:/Bsw4C+DEdqPjt8vAqaC9LAqpAQnaCQQqmolqq3S1T4=
 github.com/tent/http-link-go v0.0.0-20130702225549-ac974c61c2f9/go.mod h1:RHkNRtSLfOK7qBTHaeSX1D6BNpI3qw7NTxsmNr4RvN8=
+github.com/tidwall/raft-fastlog v0.0.0-20190329194628-f798a12ed2b3 h1:Km24Wbatpk4a0cQlmW1lGvyjzDD2biQlaqtqR1G7Cic=
+github.com/tidwall/raft-fastlog v0.0.0-20190329194628-f798a12ed2b3/go.mod h1:KNwBhka/a5Ucw5bfEzKHTEKuCO2Do1tKs+kDdu3Sbb4=
 github.com/ugorji/go v1.1.5-pre h1:jyJKFOSEbdOc2HODrf2qcCkYOdq7zzXqA9bhW5oV4fM=
 github.com/ugorji/go v1.1.5-pre/go.mod h1:FwP/aQVg39TXzItUBMwnWp9T9gPQnXw4Poh4/oBQZ/0=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=


### PR DESCRIPTION
Raft log was been handled using BoltDB, but the KV store is BadgerDB that is more performant than Bolt. This rendered in a storage speed bottleneck in the Raft log store which always comes first in write operations.

Using https://github.com/tidwall/raft-fastlog eliminates the bottleneck in Raft log storage as it is even faster than BadgerDB.

This is a breaking change when upgrading to > 2.0-RC9