### PR TITLE
fix: Revert GetStatus with concurrency forbid

### DIFF
--- a/dkron/job_test.go
+++ b/dkron/job_test.go
@@ -110,7 +110,9 @@ func Test_isRunnable(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	s, err := NewStore(nil, dir)
+	a := &Agent{}
+	s, err := NewStore(a, dir)
+	a.Store = s
 	defer s.Shutdown()
 	require.NoError(t, err)
 
@@ -129,34 +131,28 @@ func Test_isRunnable(t *testing.T) {
 			},
 			want: false,
 		},
-		{
-			name: "running forbid",
-			job: &Job{
-				Agent: &Agent{
-					Store: s,
-				},
-				Status:      StatusRunning,
-				Concurrency: ConcurrencyForbid,
-			},
-			want: false,
-		},
-		{
-			name: "success forbid",
-			job: &Job{
-				Agent: &Agent{
-					Store: s,
-				},
-				Status:      StatusRunning,
-				Concurrency: ConcurrencyForbid,
-			},
-			want: false,
-		},
+		// {
+		// 	name: "running forbid",
+		// 	job: &Job{
+		// 		Agent:       a,
+		// 		Status:      StatusRunning,
+		// 		Concurrency: ConcurrencyForbid,
+		// 	},
+		// 	want: false,
+		// },
+		// {
+		// 	name: "success forbid",
+		// 	job: &Job{
+		// 		Agent:       a,
+		// 		Status:      StatusRunning,
+		// 		Concurrency: ConcurrencyForbid,
+		// 	},
+		// 	want: false,
+		// },
 		{
 			name: "running true",
 			job: &Job{
-				Agent: &Agent{
-					Store: s,
-				},
+				Agent:   a,
 				running: true,
 			},
 			want: false,
@@ -164,9 +160,7 @@ func Test_isRunnable(t *testing.T) {
 		{
 			name: "should run",
 			job: &Job{
-				Agent: &Agent{
-					Store: s,
-				},
+				Agent: a,
 			},
 			want: true,
 		},

--- a/dkron/queries.go
+++ b/dkron/queries.go
@@ -25,7 +25,7 @@ type RunQueryParam struct {
 }
 
 // RunQuery sends a serf run query to the cluster, this is used to ask a node or nodes
-// to run a Job.
+// to run a Job. Returns a job with it's new status and next schedule.
 func (a *Agent) RunQuery(jobName string, ex *Execution) (*Job, error) {
 	start := time.Now()
 	var params *serf.QueryParam
@@ -43,7 +43,6 @@ func (a *Agent) RunQuery(jobName string, ex *Execution) (*Job, error) {
 			return nil, fmt.Errorf("agent: RunQuery error retrieving job: %s from scheduler", jobName)
 		}
 	}
-
 	job.Status = StatusRunning
 
 	if err := a.applySetJob(job.ToProto()); err != nil {


### PR DESCRIPTION
This refactor needs a second round, restoring it at the moment.

fixes #655 