### PR TITLE
Validate empty job names

### DIFF
--- a/dkron/api_test.go
+++ b/dkron/api_test.go
@@ -159,6 +159,39 @@ func TestAPIJobCreateUpdateValidationValidName(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 }
 
+func TestAPIJobCreateUpdateValidationEmptyName(t *testing.T) {
+	port := "8101"
+	baseURL := fmt.Sprintf("http://localhost:%s/v1", port)
+	dir, a := setupAPITest(t, port)
+	defer os.RemoveAll(dir)
+	defer a.Stop()
+
+	jsonStr := []byte(`{
+		"name": "testjob1",
+		"schedule": "@every 1m",
+		"executor": "shell",
+		"executor_config": {"command": "date"},
+		"disabled": true
+	}`)
+
+	resp, err := http.Post(baseURL+"/jobs", "encoding/json", bytes.NewBuffer(jsonStr))
+	require.NoError(t, err, err)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	jsonStr = []byte(`{
+		"name": "",
+		"parent_job": "testjob1",
+		"schedule": "@every 1m",
+		"executor": "shell",
+		"executor_config": {"command": "date"},
+		"disabled": true
+	}`)
+
+	resp, err = http.Post(baseURL+"/jobs", "encoding/json", bytes.NewBuffer(jsonStr))
+	require.NoError(t, err, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
 func TestAPIJobCreateUpdateValidationBadSchedule(t *testing.T) {
 	resp := postJob(t, "8097", []byte(`{
 		"name": "testjob",

--- a/dkron/grpc.go
+++ b/dkron/grpc.go
@@ -92,7 +92,6 @@ func (grpcs *GRPCServer) SetJob(ctx context.Context, setJobReq *proto.SetJobRequ
 }
 
 // DeleteJob broadcast a state change to the cluster members that will delete the job.
-// Then restart the scheduler
 // This only works on the leader
 func (grpcs *GRPCServer) DeleteJob(ctx context.Context, delJobReq *proto.DeleteJobRequest) (*proto.DeleteJobResponse, error) {
 	defer metrics.MeasureSince([]string{"grpc", "delete_job"}, time.Now())
@@ -113,7 +112,7 @@ func (grpcs *GRPCServer) DeleteJob(ctx context.Context, delJobReq *proto.DeleteJ
 	}
 	jpb := job.ToProto()
 
-	// If everything is ok, restart the scheduler
+	// If everything is ok, remove the job
 	grpcs.agent.sched.RemoveJob(job)
 
 	return &proto.DeleteJobResponse{Job: jpb}, nil

--- a/dkron/job.go
+++ b/dkron/job.go
@@ -350,6 +350,10 @@ func (j *Job) isRunnable() bool {
 
 // Validate validates whether all values in the job are acceptable.
 func (j *Job) Validate() error {
+	if j.Name == "" {
+		return fmt.Errorf("name cannot be empty")
+	}
+
 	if valid, chr := isSlug(j.Name); !valid {
 		return fmt.Errorf("name contains illegal character '%s'", chr)
 	}


### PR DESCRIPTION
The job name was not checked for being empty. Fixes #656.
Also updated comments in grpc.go.