### PR TITLE
Use time type instead of a preformatted string for times in notification template

### DIFF
--- a/dkron/notifier.go
+++ b/dkron/notifier.go
@@ -9,6 +9,7 @@ import (
 	"net/textproto"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/jordan-wright/email"
 	"github.com/sirupsen/logrus"
@@ -74,8 +75,8 @@ func (n *Notifier) buildTemplate(templ string) *bytes.Buffer {
 		Report        string
 		JobName       string
 		ReportingNode string
-		StartTime     string
-		FinishedAt    string
+		StartTime     time.Time
+		FinishedAt    time.Time
 		Success       string
 		NodeName      string
 		Output        string
@@ -83,8 +84,8 @@ func (n *Notifier) buildTemplate(templ string) *bytes.Buffer {
 		n.report(),
 		n.Execution.JobName,
 		n.Config.NodeName,
-		fmt.Sprintf("%s", n.Execution.StartedAt),
-		fmt.Sprintf("%s", n.Execution.FinishedAt),
+		n.Execution.StartedAt,
+		n.Execution.FinishedAt,
 		fmt.Sprintf("%t", n.Execution.Success),
 		n.Execution.NodeName,
 		fmt.Sprintf("%s", n.Execution.Output),

--- a/dkron/notifier_test.go
+++ b/dkron/notifier_test.go
@@ -146,12 +146,12 @@ var templateTestCases = func(n *Notifier) []templateTestCase {
 		},
 		{
 			desc:     "StartTime template variable",
-			exp:      fmt.Sprintf("%s", n.Execution.StartedAt),
+			exp:      n.Execution.StartedAt.String(),
 			template: "{{.StartTime}}",
 		},
 		{
 			desc:     "FinishedAt template variable",
-			exp:      fmt.Sprintf("%s", n.Execution.FinishedAt),
+			exp:      n.Execution.FinishedAt.String(),
 			template: "{{.FinishedAt}}",
 		},
 		{


### PR DESCRIPTION
Addresses #661.
The date format used is the same as time.String uses, with the exception of the `+-m=nnnn` value at the end. The m value is not always present, so this is reasonably backwards compatible, but not 100% guaranteed.

If the format should be changed, please let me know.