### PR TITLE
Fixes crash when plugin configuration is not defined in a job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,23 +1,22 @@
 name: Test
-on: [pull_request]
+on: [push,pull_request]
 jobs:
   build:
     name: Test
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.14
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.14
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Get dependencies
       run: go get -v -t -d ./...
 
     - name: Test without docker
       run: go test -v -timeout 200s ./...
-

--- a/dkron/job.go
+++ b/dkron/job.go
@@ -159,6 +159,9 @@ func NewJobFromProto(in *proto.Job) *Job {
 
 	procs := make(map[string]PluginConfig)
 	for k, v := range in.Processors {
+		if len(v.Config) == 0 {
+			v.Config = make(map[string]string)
+		}
 		procs[k] = v.Config
 	}
 	job.Processors = procs


### PR DESCRIPTION
If there's no plugin configuration in a job definition, dkron will crash with error:
panic: assignment to entry in nil map

This PR fixes it.