### PR TITLE
Graceful shutdown

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/distribworks/dkron/v2/dkron"
-        "github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/go-plugin"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -130,7 +130,7 @@ WAIT:
 		time.Sleep(1 * time.Second)
 	}
 
-        plugin.CleanupClients()
+	plugin.CleanupClients()
 
 	close(gracefulCh)
 

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/distribworks/dkron/v2/dkron"
-	"github.com/hashicorp/go-plugin"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -20,7 +19,7 @@ var agent *dkron.Agent
 
 const (
 	// gracefulTimeout controls how long we wait before forcefully terminating
-	gracefulTimeout = 3 * time.Second
+	gracefulTimeout = 3 * time.Hour
 )
 
 // agentCmd represents the agent command
@@ -110,17 +109,27 @@ WAIT:
 	}
 
 	// Attempt a graceful leave
-	gracefulCh := make(chan struct{})
 	log.Info("agent: Gracefully shutting down agent...")
 	go func() {
-		plugin.CleanupClients()
 		if err := agent.Stop(); err != nil {
 			fmt.Printf("Error: %s", err)
 			log.Error(fmt.Sprintf("Error: %s", err))
 			return
 		}
-		close(gracefulCh)
 	}()
+
+	gracefulCh := make(chan struct{})
+
+	for {
+		log.Info("Waiting for jobs to finish...")
+		if agent.GetRunningJobs() < 1 {
+			log.Info("No jobs left. Exiting.")
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	close(gracefulCh)
 
 	// Wait for leave or another signal
 	select {

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/distribworks/dkron/v2/dkron"
+        "github.com/hashicorp/go-plugin"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -128,6 +129,8 @@ WAIT:
 		}
 		time.Sleep(1 * time.Second)
 	}
+
+        plugin.CleanupClients()
 
 	close(gracefulCh)
 

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -881,3 +881,13 @@ func (a *Agent) applySetJob(job *proto.Job) error {
 func (a *Agent) RaftApply(cmd []byte) raft.ApplyFuture {
 	return a.raft.Apply(cmd, raftTimeout)
 }
+
+// GetRunningJobs returns amount of active jobs
+func (a *Agent) GetRunningJobs() int {
+	job := 0
+	runningExecutions.Range(func(k, v interface{}) bool {
+		job = job + 1
+		return true
+	})
+	return job
+}


### PR DESCRIPTION
When I started to test graceful shutdown of worker type agents, it appeared that they don't wait for their running jobs before shutdown.
If I recall correctly, plugin.CleanupClients() kill plugins immediately, causing childs (in case of shell executor) to die.

This PR does the following:
- SIGTERM received
- Agent leaves cluster to not accept new jobs 
- Agent waits for active jobs to finish during 3h
- Exits when running jobs finished or gracefulTimeout reached

Note: Running jobs successfully can send ExecutionDone to leader even after agent left cluster.
