### PR TITLE
Defer panic fix

### DIFF
--- a/dkron/grpc_client.go
+++ b/dkron/grpc_client.go
@@ -63,7 +63,6 @@ func (grpcc *GRPCClient) ExecutionDone(addr string, execution *Execution) error 
 	var conn *grpc.ClientConn
 
 	conn, err := grpcc.Connect(addr)
-	defer conn.Close()
 	if err != nil {
 		log.WithError(err).WithFields(logrus.Fields{
 			"method":      "ExecutionDone",
@@ -77,6 +76,7 @@ func (grpcc *GRPCClient) ExecutionDone(addr string, execution *Execution) error 
 	if err != nil {
 		if err.Error() == fmt.Sprintf("rpc error: code = Unknown desc = %s", ErrNotLeader.Error()) {
 			log.Info("grpc: ExecutionDone forwarded to the leader")
+			conn.Close()
 			return nil
 		}
 
@@ -92,7 +92,7 @@ func (grpcc *GRPCClient) ExecutionDone(addr string, execution *Execution) error 
 		"from":        edr.From,
 		"payload":     string(edr.Payload),
 	}).Debug("grpc: Response from method")
-
+	conn.Close()
 	return nil
 }
 


### PR DESCRIPTION
Defer causes panic if there's nothing to close, i.e. connection was not successful.
Can happen during crash of leader if I'm recall it right.