### PR TITLE
Execution load balancing

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -780,8 +780,9 @@ func (a *Agent) processFilteredNodes(job *Job) ([]string, map[string]string, err
 					break
 				}
 				nodes = append(nodes, candidates[0])
-				candidates = candidates[:1]
+				candidates = candidates[1:]
 			}
+			candidates = nil
 
 		}
 	}


### PR DESCRIPTION
serf.Members() seems to usually return same order of nodes.

When we have job definition with tag "label:1", the job is executed usually on the same worker agent .
This PR adds shuffling, before returning a node for execution.

After shuffling is added, we see good load distribution among worker pool with matching tag.

![Screenshot 2020-03-05 at 13 44 06](https://user-images.githubusercontent.com/1649386/75978541-68fba500-5ee7-11ea-86db-505f034cc567.png)
