### PR TITLE
isLeader handler added

### DIFF
--- a/dkron/api.go
+++ b/dkron/api.go
@@ -255,7 +255,7 @@ func (h *HTTPTransport) isLeaderHandler(c *gin.Context) {
 	if isleader {
 		renderJSON(c, http.StatusOK, "I am a leader")
 	} else {
-		renderJSON(c, http.StatusNotFound, "I am not a leader")
+		renderJSON(c, http.StatusNotFound, "I am a follower")
 	}
 }
 

--- a/dkron/api.go
+++ b/dkron/api.go
@@ -67,6 +67,7 @@ func (h *HTTPTransport) APIRoutes(r *gin.RouterGroup, middleware ...gin.HandlerF
 	v1.GET("/", h.indexHandler)
 	v1.GET("/members", h.membersHandler)
 	v1.GET("/leader", h.leaderHandler)
+	v1.GET("/isleader", h.isLeaderHandler)
 	v1.POST("/leave", h.leaveHandler)
 
 	v1.POST("/jobs", h.jobCreateOrUpdateHandler)
@@ -247,6 +248,15 @@ func (h *HTTPTransport) leaderHandler(c *gin.Context) {
 		c.AbortWithStatus(http.StatusNotFound)
 	}
 	renderJSON(c, http.StatusOK, member)
+}
+
+func (h *HTTPTransport) isLeaderHandler(c *gin.Context) {
+	isleader := h.agent.IsLeader()
+	if isleader {
+		renderJSON(c, http.StatusOK, "I am a leader")
+	} else {
+		renderJSON(c, http.StatusNotFound, "I am not a leader")
+	}
 }
 
 func (h *HTTPTransport) leaveHandler(c *gin.Context) {

--- a/website/content/swagger.yaml
+++ b/website/content/swagger.yaml
@@ -173,6 +173,18 @@ paths:
           description: Successful response
           schema:
             $ref: '#/definitions/member'
+  /isleader:
+    get:
+      description: |
+        Check if node is a leader or follower.
+      operationId: getIsLeader
+      tags:
+        - default
+      responses:
+        200:
+          description: Node is a leader
+        404:
+          description: Node is a follower
   /leave:
     post:
       description: |

--- a/website/content/v1.2/swagger.yaml
+++ b/website/content/v1.2/swagger.yaml
@@ -166,6 +166,18 @@ paths:
           description: Successful response
           schema:
             $ref: '#/definitions/member'
+  /isleader:
+    get:
+      description: |
+        Check if node is a leader or follower.
+      operationId: getIsLeader
+      tags:
+        - default
+      responses:
+        200:
+          description: Node is a leader
+        404:
+          description: Node is a follower
   /leave:
     get:
       description: |


### PR DESCRIPTION
This is a handler which tells if a node is a leader or not.
This is required for Dkron HA deployment in Kubernetes environment.
Example Kubernetes manifests will be in another PR