### PR TITLE
Kubernetes support

### DIFF
--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -1,19 +1,31 @@
-FROM alpine
+FROM golang:1.14-alpine as builder
 LABEL maintainer="Victor Castell <victor@victorcastell.com>"
 
+RUN mkdir -p /app
+WORKDIR /app
+
+ENV GO111MODULE=on
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+RUN apk add build-base
+
+COPY . .
+RUN CGO_ENABLED=0 go install ./...
+
+FROM alpine
+# JQ Required for prestop hook to remove peer from cluster on pod delete action
 RUN set -x \
-	&& buildDeps='bash ca-certificates openssl tzdata' \
-	&& apk add --update $buildDeps \
-	&& rm -rf /var/cache/apk/* \
-	&& mkdir -p /opt/local/dkron
+        && buildDeps='bash ca-certificates openssl tzdata jq' \
+        && apk add --update $buildDeps \
+        && rm -rf /var/cache/apk/* \
+        && mkdir -p /opt/local/dkron
+
+COPY --chown=0:0 --from=builder /go/bin/dkron* /opt/local/dkron/
 
 EXPOSE 8080 8946
 
 ENV SHELL /bin/bash
 WORKDIR /opt/local/dkron
-
-COPY dkron .
-COPY dkron-* ./
 ENTRYPOINT ["/opt/local/dkron/dkron"]
-
 CMD ["--help"]

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -413,6 +413,10 @@ func (a *Agent) setupSerf() (*serf.Serf, error) {
 	serfConfig.UserCoalescePeriod = 3 * time.Second
 	serfConfig.UserQuiescentPeriod = time.Second
 
+	if a.config.Kubernetes {
+		serfConfig.ReconnectTimeout = 5 * time.Second
+	}
+
 	// Create a channel to listen for events from Serf
 	a.eventCh = make(chan serf.Event, 64)
 	serfConfig.EventCh = a.eventCh

--- a/dkron/config.go
+++ b/dkron/config.go
@@ -153,6 +153,10 @@ type Config struct {
 
 	// StatsdAddr is the statsd standard server to be used for sending metrics.
 	StatsdAddr string `mapstructure:"statsd-addr"`
+
+	// Kubernetes is used to set faster reap timeout, as node won't come back with same
+	// IP after pod restart
+	Kubernetes bool
 }
 
 // DefaultBindPort is the default port that dkron will use for Serf communication
@@ -214,6 +218,7 @@ func ConfigFlagSet() *flag.FlagSet {
 	cmdFlags.String("data-dir", c.DataDir, "Specifies the directory to use for server-specific data, including the replicated log. By default, this is the top-level data-dir, like [/var/lib/dkron]")
 	cmdFlags.String("datacenter", c.Datacenter, "Specifies the data center of the local agent. All members of a datacenter should share a local LAN connection.")
 	cmdFlags.String("region", c.Region, "Specifies the region the Dkron agent is a member of. A region typically maps to a geographic region, for example us, with potentially multiple zones, which map to datacenters such as us-west and us-east")
+	cmdFlags.Bool("kubernetes", false, "Set this to true if you run in Kubernetes. Reconnect timeout is set to 5 seconds instead of 24h. This is the amount of time to attempt to reconnect to a failed node before giving up and considering it completely gone. As we run in Kubernetes and the pod will come back with a new IP, there is no reason to try reconnects for 24h. Also Raft behaves oddly if node is not reaped, but returned with same ID, but different IP.")
 
 	// Notifications
 	cmdFlags.String("mail-host", "", "Mail server host address to use for notifications")

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,52 @@
+## This is a Dkron HA solution for running in Kubernetes
+
+### Overview
+#### Bootstrap process
+1. StatefulSet launches requested amount of dkron-server pods at the same time, so that cluster could be automatically bootstrapped
+2. Dkron itself is launched with wrapper init script
+    * Script does the following job
+      1. Checks when all dkron-server pods fqdns are resolving to POD ip
+      1. Checks if the cluster is already bootstrapped, by checking if there's already a leader.  
+      If there's a leader, then init script is not passing --bootstrap-expect parameter to Dkron arguments, to not cause a failover on a working cluster on dkron server pod restart.     
+      Otherwise --bootstrap-expect parameter is passed with a value of INITIAL_CLUSTER_SUZE environment variable which should match statefulset replicas values during initial launch.
+      1. launches dkron binary with a FQDN list of cluster peers
+    4. Now all pods are able to discover each other and select a leader
+    5. Waits for SIGTERM
+
+#### Pod restart process
+1.  Init script receives SIGTERM on pod termination
+1. Init script sends SIGTERM to dkron-server, causing it to shutdown
+1. Sleeps for 75 seconds, as it's the calculated by trial and error time to dkron server to forget about the ex-node. It's required, because IP address of a pod changes after a restart, but Raft expects node to come back with same IP
+1. Init script sends "raft remove-peer" request to a dkron to remove a node from Raft. That's where Raft forgets about a node that will never comeback with same IP.
+1. Exits container
+1. Pod terminated
+1. New pod started
+1. Init script checks when all dkron-server pods fqdns are resolving to POD ip
+1. Init script checks if the cluster is already bootstrapped, by checking if there's already a leader. If there's a leader, then init script is not passing --bootstrap-expect parameter to Dkron arguments, as it causes failover on a pod restart. Otherwise --bootstrap-expect parameter is passed with a value of INITIAL_CLUSTER_SUZE environment variable which should match statefulset replicas values during initial launch.
+1. Init script launches dkron server with a FQDN list of cluster peers
+1. Dkron server joins to cluster with a new IP address
+1. Init script waits for SIGTERM
+
+#### dkron-server-leader service
+This is a service pointing to a cluster leader.
+That is required for checking if there's a cluster is already bootstrapped and removing pod from Raft on shutdown.
+
+#### Label updater
+There is a labelupdater sidecar container that is checking self dkron if it's leader or follower, and updating self pod label according to current role.
+
+### Configuration
+#### Environment variables
+* INITIAL_CLUSTER_SIZE  
+  Set the number same as replicas values in StatefulSet.  
+  This is required for proper bootstrapping
+
+* STATEFULSET_NAME  
+  Set this same as your statefulset name.  
+  This is required for proper FQDN build
+
+
+#### Service account and worker agent discovery
+Service account with provided binding to role is used to allow dkron-server pod to update leader label.  
+Second thing that Dkron worker agents are using Kubernetes service discovery by labels in order to find the cluster to join.  
+All Dkron worker agents should be run with appropriate service account that has permission to list pods by label.  
+

--- a/kubernetes/dkron-server-leader-svc.yaml
+++ b/kubernetes/dkron-server-leader-svc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dkron-server-leader
+  labels:
+    app: dkron-server
+spec:
+  ports:
+  - name: web
+    port: 8080
+  clusterIP: None
+  selector:
+    app: dkron-server
+    leader: "true"

--- a/kubernetes/dkron-server-sts.yaml
+++ b/kubernetes/dkron-server-sts.yaml
@@ -1,0 +1,170 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: dkron-server
+  labels:
+    app: dkron-server
+    component: server
+spec:
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: OnDelete # During rolling upgrade kuberenetes don't know who's leader and restarting pods in an order. That may cause multiple failovers. Maybe it's better to check who's leader and manually restart followers, then leader, to have a single failover.
+  serviceName: dkron-server
+  replicas: 3
+  selector:
+    matchLabels:
+      app: dkron-server
+      component: server
+  template:
+    metadata:
+      name: dkron-server
+      labels:
+        app: dkron-server
+        component: server
+    spec:
+      terminationGracePeriodSeconds: 300
+      serviceAccount: dkron-server
+      securityContext:
+        runAsUser: 0 # TODO. Running as root is a bad idea
+      containers:
+      - name: labelupdater
+        image: bitnami/kubectl:1.17
+        command:
+          - "/bin/bash"
+          - "-c"
+          - |
+            _term() {
+              echo "Caught SIGTERM. Forcing leader pod label to false"
+              kubectl label pods $(hostname) leader=false --overwrite=true
+              exit 0
+              }
+
+            trap _term SIGTERM
+
+            touch /tmp/status
+            while true; do
+              curl -s -o - --connect-timeout 10 http://127.0.0.1:8080/v1/isleader| tr -d '"' > /tmp/status_tmp
+
+              if [[ `cat /tmp/status_tmp` == `cat /tmp/status` ]]; then
+                echo "No status changed. Skipping"
+              elif [[ `cat /tmp/status_tmp` == "I am a leader" ]]; then
+                kubectl label pods $(hostname) leader=true --overwrite=true
+                echo "I am a leader" > /tmp/status
+              elif [[ `cat /tmp/status_tmp` == "I am follower" ]]; then
+                kubectl label pods $(hostname) leader=false --overwrite=true
+                echo "I am a follower" > /tmp/status
+              else
+                echo "Error parsing the output"
+              fi
+
+              echo "sleeping 5 sec"
+              sleep 5
+            done
+      - name: dkron
+        image: dkron/dkron
+        ports:
+        - name: web
+          containerPort: 8080
+        - name: rpc
+          containerPort: 8946
+        - name: raft
+          containerPort: 6868
+        env:
+        - name: INITIAL_CLUSTER_SIZE
+          value: "3"
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: STATEFULSET_NAME
+          value: dkron-server
+        - name: STATEFULSET_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        command:
+          - "/bin/sh"
+          - "-c"
+          - |
+            set -o pipefail
+
+            _term() {
+               echo "Caught SIGTERM"
+               kill -TERM "$child"
+               echo "Waiting for 75 seconds, as it the approximate time to reap left node"
+               sleep 75
+               echo "Removing self from Raft"
+               /opt/local/dkron/dkron raft remove-peer --peer-id=$(hostname) --rpc-addr="$(wget -q -O - http://dkron-server-leader:8080/v1/leader?pretty=true|jq .Tags.rpc_addr -r)"
+               echo "Done"
+               exit 0
+             }
+
+            if [ -z "$POD_IP" ]; then
+              POD_IP=$(hostname -i)
+            fi
+
+            FQDN_SUFFIX="${STATEFULSET_NAME}.${STATEFULSET_NAMESPACE}.svc.cluster.local"
+            NODE_NAME="$(hostname -s).${FQDN_SUFFIX}"
+
+            JOIN_PEERS=""
+            for i in $( seq 0 $((${INITIAL_CLUSTER_SIZE} - 1)) ); do
+              JOIN_PEERS="${JOIN_PEERS}${JOIN_PEERS:+ }${STATEFULSET_NAME}-${i}.${FQDN_SUFFIX}"
+            done
+
+            # Require multiple loops in the case of unstable DNS resolution
+            SUCCESS_LOOPS=5
+            while [ "$SUCCESS_LOOPS" -gt 0 ]; do
+              ALL_READY=true
+              JOIN_LAN=""
+              for THIS_PEER in $JOIN_PEERS; do
+                  # Make sure we can resolve hostname and ping IP
+                  if PEER_IP="$( ( ping -c 1 $THIS_PEER || true ) | awk -F'[()]' '/PING/{print $2}')" && [ "$PEER_IP" != "" ]; then
+                    if [ "${PEER_IP}" != "${POD_IP}" ]; then
+                      JOIN_LAN="${JOIN_LAN}${JOIN_LAN:+ } --retry-join=$THIS_PEER"
+                    fi
+                  else
+                    ALL_READY=false
+                    break
+                  fi
+              done
+              if $ALL_READY; then
+                SUCCESS_LOOPS=$(( SUCCESS_LOOPS - 1 ))
+                echo "LAN peers appear ready, $SUCCESS_LOOPS verifications left"
+              else
+                echo "Waiting for LAN peer $THIS_PEER..."
+              fi
+              sleep 1s
+            done
+
+            LEADER=$(wget -q -O - http://dkron-server-leader:8080/v1/leader?pretty=true|jq .Tags.rpc_addr -r)
+
+            if [ -z "${LEADER}" ]; then
+                BOOTSTRAP_EXPECT="--bootstrap-expect $( echo "$JOIN_PEERS" | wc -w )"
+            else
+                BOOTSTRAP_EXPECT=""
+            fi
+
+            trap _term SIGTERM
+            /opt/local/dkron/dkron agent \
+              --server \
+              --kubernetes \
+              ${BOOTSTRAP_EXPECT} \
+              ${JOIN_LAN} &
+
+            child=$!
+            wait "$child"
+
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          periodSeconds: 30
+          failureThreshold: 3
+          initialDelaySeconds: 120 # Sometimes it takes a lot to rejoin node to a cluster. Pausing there in case we do rolling pod update.
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          periodSeconds: 30
+          failureThreshold: 3
+          initialDelaySeconds: 120

--- a/kubernetes/dkron-server-svc.yaml
+++ b/kubernetes/dkron-server-svc.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dkron-server
+  labels:
+    app: dkron-server
+spec:
+  publishNotReadyAddresses: true
+  ports:
+  - name: web
+    port: 8080
+  - name: rpc
+    port: 8946
+  - name: raft
+    port: 6868
+  - name: http-metrics
+    port: 9102
+  clusterIP: None
+  selector:
+    app: dkron-server

--- a/kubernetes/dkron-worker-agent-cm.yaml
+++ b/kubernetes/dkron-worker-agent-cm.yaml
@@ -1,0 +1,11 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: dkron-worker
+data:
+  dkron.yml: |-
+    kubernetes: true
+    retry-join: ["provider=k8s label_selector=\"app=dkron-server\""]
+    # Uncomment below to set a tag for a worker
+    tags:
+      worker: cron

--- a/kubernetes/dkron-worker-agent-deployment.yaml
+++ b/kubernetes/dkron-worker-agent-deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+  labels:
+    app: dkron-worker
+    component: worker
+  name: dkron-worker
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: dkron-worker
+      component: worker
+  template:
+    metadata:
+      labels:
+        app: dkron-worker
+        component: worker
+      name: dkron-worker
+    spec:
+      containers:
+      - args:
+        - agent
+        volumeMounts:
+        - name: dkron-worker
+          mountPath: /opt/local/dkron/config
+        image: dkron/dkron
+        name: dkron
+        ports:
+        - containerPort: 8080
+          name: web
+          protocol: TCP
+        - containerPort: 8946
+          name: rpc
+          protocol: TCP
+        - containerPort: 6868
+          name: raft
+          protocol: TCP
+      serviceAccount: dkron
+      terminationGracePeriodSeconds: 3600 # Max wait time for jobs to be finished, then force kill the pod.
+      volumes:
+      - name: dkron-worker
+        configMap:
+          name: dkron-worker

--- a/kubernetes/role.yaml
+++ b/kubernetes/role.yaml
@@ -1,0 +1,11 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: dkron
+  labels:
+    app: dkron
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list", "patch", "get"]
+

--- a/kubernetes/rolebinding.yaml
+++ b/kubernetes/rolebinding.yaml
@@ -1,0 +1,14 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: dkron-server
+  labels:
+    app: dkron-server
+subjects:
+  - kind: ServiceAccount
+    name: dkron
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: dkron-server
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/sa.yaml
+++ b/kubernetes/sa.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dkron
+  labels:
+    app: dkron-server


### PR DESCRIPTION
This PR contains:
* Kubernetes manifests for running Dkron server in HA mode
* Kubernetes manifests for running Dkron worker agents that are able to discover and join Dkron server
* Building in Docker and baking image in one step.
   This will allows to build own image on any platform
* Compiling with CGO_ENABLED=0.  
   Dkron didn't work on older Linux distros without this if binary was compiled on some newer distro.
   In our case we were just copying precompiled binary to our existing apps to use dkron with shell executor plugin.
* Added jq to Docker image, as it's required for Kubernetes, to parse Dkron API output.

Kubernetes has a specifics that IP addresses of pods are changed on each restart. This is not working good with Dkron.
So, Dkron is launched with wrapper script that is doing all the job of removing peers from cluster

This solution comes with no storage persistence, as it's currently working bad with Raft in Kubernetes.
In our case we store job definitions in Terraform, and this is our source of truth and a backup.
In case we lose cluster, we can just bootstrap a new one and apply Terraform in seconds, which will configure Dkron through API