### PR TITLE
Don't block execution if concurrency is allowed

### DIFF
--- a/dkron/job.go
+++ b/dkron/job.go
@@ -348,7 +348,6 @@ func (j *Job) isRunnable() bool {
 	if j.running {
 		log.WithField("job", j.Name).
 			Warning("job: Skipping execution because last execution still broadcasting, consider increasing schedule interval")
-		return false
 	}
 
 	return true


### PR DESCRIPTION
Maybe I get it wrong, but it looks to me that even if concurrency set to allow, isRunnable() still returns false