### PR TITLE
refactor: Get RPC Addr using IP templates

### DIFF
--- a/cmd/dkron.go
+++ b/cmd/dkron.go
@@ -14,6 +14,9 @@ import (
 var cfgFile string
 var config = dkron.DefaultConfig()
 
+var rpcAddr string
+var ip string
+
 // dkronCmd represents the dkron command
 var dkronCmd = &cobra.Command{
 	Use:   "dkron",

--- a/cmd/leave.go
+++ b/cmd/leave.go
@@ -5,8 +5,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var rpcAddr string
-
 // versionCmd represents the version command
 var leaveCmd = &cobra.Command{
 	Use:   "leave",
@@ -14,11 +12,20 @@ var leaveCmd = &cobra.Command{
 	Long: `Stop stops an agent, if the agent is a server and is running for election
 	stop running for election, if this server was the leader
 	this will force the cluster to elect a new leader and start a new scheduler.`,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		ipa, err := dkron.ParseSingleIPTemplate(rpcAddr)
+		if err != nil {
+			return err
+		}
+		ip = ipa
+
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var gc dkron.DkronGRPCClient
 		gc = dkron.NewGRPCClient(nil, nil)
 
-		if err := gc.Leave(rpcAddr); err != nil {
+		if err := gc.Leave(ip); err != nil {
 			return err
 		}
 
@@ -28,5 +35,5 @@ var leaveCmd = &cobra.Command{
 
 func init() {
 	dkronCmd.AddCommand(leaveCmd)
-	leaveCmd.PersistentFlags().StringVar(&rpcAddr, "rpc-addr", "127.0.0.1:6868", "gRPC address of the agent")
+	leaveCmd.PersistentFlags().StringVar(&rpcAddr, "rpc-addr", "{{ GetPrivateIP }}:6868", "gRPC address of the agent")
 }

--- a/cmd/raft.go
+++ b/cmd/raft.go
@@ -13,6 +13,15 @@ var raftCmd = &cobra.Command{
 	Use:   "raft [command]",
 	Short: "Command to perform some raft operations",
 	Long:  ``,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		ipa, err := dkron.ParseSingleIPTemplate(rpcAddr)
+		if err != nil {
+			return err
+		}
+		ip = ipa
+
+		return nil
+	},
 }
 
 var raftListCmd = &cobra.Command{
@@ -23,7 +32,7 @@ var raftListCmd = &cobra.Command{
 		var gc dkron.DkronGRPCClient
 		gc = dkron.NewGRPCClient(nil, nil)
 
-		reply, err := gc.RaftGetConfiguration(rpcAddr)
+		reply, err := gc.RaftGetConfiguration(ip)
 		if err != nil {
 			return err
 		}
@@ -55,7 +64,7 @@ var raftRemovePeerCmd = &cobra.Command{
 		var gc dkron.DkronGRPCClient
 		gc = dkron.NewGRPCClient(nil, nil)
 
-		if err := gc.RaftRemovePeerByID(rpcAddr, peerID); err != nil {
+		if err := gc.RaftRemovePeerByID(ip, peerID); err != nil {
 			return err
 		}
 		fmt.Println("Peer removed")
@@ -65,7 +74,7 @@ var raftRemovePeerCmd = &cobra.Command{
 }
 
 func init() {
-	raftCmd.PersistentFlags().StringVar(&rpcAddr, "rpc-addr", "127.0.0.1:6868", "gRPC address of the agent")
+	raftCmd.PersistentFlags().StringVar(&rpcAddr, "rpc-addr", "{{ GetPrivateIP }}:6868", "gRPC address of the agent.")
 	raftRemovePeerCmd.Flags().StringVar(&peerID, "peer-id", "", "Remove a Dkron server with the given ID from the Raft configuration.")
 
 	raftCmd.AddCommand(raftListCmd)

--- a/dkron/config.go
+++ b/dkron/config.go
@@ -239,7 +239,7 @@ func ConfigFlagSet() *flag.FlagSet {
 // initialized and have sane defaults.
 func (c *Config) normalizeAddrs() error {
 	if c.BindAddr != "" {
-		ipStr, err := parseSingleIPTemplate(c.BindAddr)
+		ipStr, err := ParseSingleIPTemplate(c.BindAddr)
 		if err != nil {
 			return fmt.Errorf("Bind address resolution failed: %v", err)
 		}
@@ -247,7 +247,7 @@ func (c *Config) normalizeAddrs() error {
 	}
 
 	if c.HTTPAddr != "" {
-		ipStr, err := parseSingleIPTemplate(c.HTTPAddr)
+		ipStr, err := ParseSingleIPTemplate(c.HTTPAddr)
 		if err != nil {
 			return fmt.Errorf("Bind address resolution failed: %v", err)
 		}
@@ -265,7 +265,7 @@ func (c *Config) normalizeAddrs() error {
 
 // parseSingleIPTemplate is used as a helper function to parse out a single IP
 // address from a config parameter.
-func parseSingleIPTemplate(ipTmpl string) (string, error) {
+func ParseSingleIPTemplate(ipTmpl string) (string, error) {
 	out, err := template.Parse(ipTmpl)
 	if err != nil {
 		return "", fmt.Errorf("unable to parse address template %q: %v", ipTmpl, err)
@@ -295,7 +295,7 @@ func parseSingleIPTemplate(ipTmpl string) (string, error) {
 //
 // Loopback is only considered a valid advertise address in dev mode.
 func normalizeAdvertise(addr string, bind string, defport int, dev bool) (string, error) {
-	addr, err := parseSingleIPTemplate(addr)
+	addr, err := ParseSingleIPTemplate(addr)
 	if err != nil {
 		return "", fmt.Errorf("Error parsing advertise address template: %v", err)
 	}
@@ -336,7 +336,7 @@ func normalizeAdvertise(addr string, bind string, defport int, dev bool) (string
 	}
 
 	// Bind is not localhost but not a valid advertise IP, use first private IP
-	addr, err = parseSingleIPTemplate("{{ GetPrivateIP }}")
+	addr, err = ParseSingleIPTemplate("{{ GetPrivateIP }}")
 	if err != nil {
 		return "", fmt.Errorf("Unable to parse default advertise address: %v", err)
 	}


### PR DESCRIPTION
Making the IP template parsing public to be used in other commands.

This will use the default address as in the agent bind address, the first private IP by default.