### PR TITLE
fix: Resetting the status and next params

### DIFF
--- a/dkron/grpc_client.go
+++ b/dkron/grpc_client.go
@@ -78,7 +78,7 @@ func (grpcc *GRPCClient) ExecutionDone(addr string, execution *Execution) error 
 	edr, err := d.ExecutionDone(context.Background(), &proto.ExecutionDoneRequest{Execution: execution.ToProto()})
 	if err != nil {
 		if err.Error() == fmt.Sprintf("rpc error: code = Unknown desc = %s", ErrNotLeader.Error()) {
-			log.Info("grpc: ExecutionDone forwarded to the leader") //TODO
+			log.Info("grpc: ExecutionDone forwarded to the leader")
 			conn.Close()
 			return nil
 		}

--- a/dkron/invoke.go
+++ b/dkron/invoke.go
@@ -118,6 +118,7 @@ func (a *Agent) invokeJob(job *Job, execution *Execution) error {
 		Execution: execution.ToProto(),
 	}); err != nil {
 		// In case of error means that maybe the server is gone so fallback to ExecutionDone
+		log.WithError(err).WithField("job", job.Name).Error("invoke: error sending the final execution, falling back to ExecutionDone")
 		return a.GRPCClient.ExecutionDone(rpcServer, execution)
 	}
 
@@ -125,8 +126,11 @@ func (a *Agent) invokeJob(job *Job, execution *Execution) error {
 	reply, err := stream.CloseAndRecv()
 	if err != nil {
 		// In case of error means that maybe the server is gone so fallback to ExecutionDone
+		log.WithError(err).WithField("job", job.Name).Error("invoke: error closing the stream, falling back to ExecutionDone")
 		return a.GRPCClient.ExecutionDone(rpcServer, execution)
 	}
+
+	// TODO add better logging
 	log.WithField("from", reply.From).Debug("agent: AgentRun reply")
 
 	return nil

--- a/dkron/store.go
+++ b/dkron/store.go
@@ -127,6 +127,9 @@ func (s *Store) SetJob(job *Job, copyDependentJobs bool) error {
 			if len(ej.DependentJobs) != 0 && copyDependentJobs {
 				job.DependentJobs = ej.DependentJobs
 			}
+			if ej.Status != "" {
+				job.Status = ej.Status
+			}
 		}
 
 		if job.Schedule != ej.Schedule {
@@ -134,6 +137,8 @@ func (s *Store) SetJob(job *Job, copyDependentJobs bool) error {
 			if err != nil {
 				return err
 			}
+		} else {
+			job.Next = ej.Next
 		}
 
 		pbj := job.ToProto()


### PR DESCRIPTION
When posting an existing job don't overwrite the last status if present.

Don't overwrite the next execution time if schedule not changed.

Also better logging in invoke