### PR TITLE
fix: Get node RCP addr for retry

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -851,11 +851,11 @@ func (a *Agent) checkAndSelectServer() (string, error) {
 	}
 
 	for _, peer := range peers {
-		log.Debugf("Checking peer: %v", peer)
+		log.WithField("peer", peer).Debug("Checking peer")
 		conn, err := net.DialTimeout("tcp", peer, 1*time.Second)
 		if err == nil {
 			conn.Close()
-			log.Debugf("Found good peer: %v", peer)
+			log.WithField("peer", peer).Debug("Found good peer")
 			return peer, nil
 		}
 	}

--- a/dkron/grpc.go
+++ b/dkron/grpc.go
@@ -206,7 +206,6 @@ func (grpcs *GRPCServer) ExecutionDone(ctx context.Context, execDoneReq *proto.E
 		execution.Attempt++
 
 		// Keep all execution properties intact except the last output
-		// as it could exceed serf query limits.
 		execution.Output = ""
 
 		log.WithFields(logrus.Fields{

--- a/dkron/job.go
+++ b/dkron/job.go
@@ -237,7 +237,7 @@ func (j *Job) Run() {
 		ex := NewExecution(j.Name)
 
 		if _, err := j.Agent.Run(j.Name, ex); err != nil {
-			log.WithError(err).Error("job: Error sending Run query to serf cluster")
+			log.WithError(err).Error("job: Error running job")
 		}
 	}
 }

--- a/dkron/run.go
+++ b/dkron/run.go
@@ -35,7 +35,13 @@ func (a *Agent) Run(jobName string, ex *Execution) (*Job, error) {
 			return nil, fmt.Errorf("agent: Run error processing filtered nodes: %w", err)
 		}
 	} else {
-		filterMap = map[string]string{ex.NodeName: ""}
+		var addr string
+		for _, m := range a.serf.Members() {
+			if ex.NodeName == m.Name {
+				addr = m.Tags["rpc_addr"]
+			}
+		}
+		filterMap = map[string]string{ex.NodeName: addr}
 	}
 
 	log.WithField("nodes", filterMap).Debug("agent: Filtered nodes to run")

--- a/dkron/run.go
+++ b/dkron/run.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/hashicorp/serf/serf"
 	"github.com/sirupsen/logrus"
 )
 
@@ -32,18 +33,27 @@ func (a *Agent) Run(jobName string, ex *Execution) (*Job, error) {
 	if ex.Attempt <= 1 {
 		filterMap, _, err = a.processFilteredNodes(job)
 		if err != nil {
-			return nil, fmt.Errorf("agent: Run error processing filtered nodes: %w", err)
+			return nil, fmt.Errorf("run error processing filtered nodes: %w", err)
 		}
 	} else {
+		// In case of retrying, find the rpc address of the node or return with an error
 		var addr string
 		for _, m := range a.serf.Members() {
 			if ex.NodeName == m.Name {
-				addr = m.Tags["rpc_addr"]
+				if m.Status == serf.StatusAlive {
+					addr = m.Tags["rpc_addr"]
+				} else {
+					return nil, fmt.Errorf("retry node is gone: %s for job %s", ex.NodeName, ex.JobName)
+				}
 			}
 		}
 		filterMap = map[string]string{ex.NodeName: addr}
 	}
 
+	// In case no nodes found, return reporting the error
+	if len(filterMap) < 1 {
+		return nil, fmt.Errorf("no target nodes found to run job %s", ex.JobName)
+	}
 	log.WithField("nodes", filterMap).Debug("agent: Filtered nodes to run")
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
Find the retry node address in the cluster and provides better logging.