### PR TITLE
Prometheus metrics. Configurable timeout and memory limit

### DIFF
--- a/builtin/bins/dkron-executor-shell/main.go
+++ b/builtin/bins/dkron-executor-shell/main.go
@@ -1,11 +1,24 @@
 package main
 
 import (
+	"net/http"
+	"os"
+
 	dkplugin "github.com/distribworks/dkron/v3/plugin"
 	"github.com/hashicorp/go-plugin"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	log "github.com/sirupsen/logrus"
 )
 
 func main() {
+	finish := make(chan bool)
+	promServer := http.NewServeMux()
+	promServer.Handle("/metrics", promhttp.Handler())
+
+	go func() {
+		http.ListenAndServe(":"+getEnv("PROMETHEUS_PORT"), promServer)
+	}()
+
 	plugin.Serve(&plugin.ServeConfig{
 		HandshakeConfig: dkplugin.Handshake,
 		Plugins: map[string]plugin.Plugin{
@@ -15,4 +28,18 @@ func main() {
 		// A non-nil value here enables gRPC serving for this plugin...
 		GRPCServer: plugin.DefaultGRPCServer,
 	})
+	<-finish
+}
+
+func getEnv(key string) string {
+	v, ok := os.LookupEnv(key)
+	if v == "" {
+		log.Warningf("empty value for environment variable %s", key)
+		return "set_my_env_var"
+	}
+	if !ok {
+		log.Warningf("environment variable %s is not set", key)
+		return "var_is_empty"
+	}
+	return v
 }

--- a/builtin/bins/dkron-executor-shell/prometheus.go
+++ b/builtin/bins/dkron-executor-shell/prometheus.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	namespace = "dkron_job"
+)
+
+var (
+	cpuUsage = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "cpu_usage",
+		Help:      "CPU usage by job",
+	},
+		[]string{"job_name"})
+
+	memUsage = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "mem_usage_kb",
+		Help:      "Current memory consumed by job",
+	},
+		[]string{"job_name"})
+
+	executionTime = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "execution_time_seconds",
+		Help:      "Duration of job execution",
+	})
+		
+	exitCode = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "exit_code",
+		Help:      "Exit code of a job",
+	})
+		
+
+	lastExecutionTimestamp = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "last_execution_unixtimestamp",
+	})
+		
+)
+
+func updateMetric(jobName string, metricName *prometheus.GaugeVec, value float64) {
+	metricName.WithLabelValues(jobName).Set(value)
+}
+


### PR DESCRIPTION
Here were have:
- configurable timeout for job execution
- configurable memory limit for a shell job
- prometheus realtime cpu and memory consumption while it's working
- prometheus push style metrics after job execution. Useful for monitoring if job was executed in time (that's how we found misses of executions). Also there: exit code, duration of a job, last execution timestamp, 

In cases anyone needs it, we can add a flag to turn on/off metrics expose through prometheus. 