### PR TITLE
Github Action for release (binary and docker)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,11 @@
 name: Test
-on: [push,pull_request]
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
+  pull_request:
 jobs:
   build:
     name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  push:
+    branches-ignore:
+      - '**'
+    tags:
+      - 'v*.*.*'
+      # to be used by fork patch-releases ^^
+      - 'v*.*.*-*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Set up Go
+        uses: actions/setup-go@master
+        with:
+          go-version: 1.14.x
+
+      - name: Prepare
+        id: prepare
+        run: |
+            TAG=${GITHUB_REF#refs/tags/}
+            echo ::set-output name=tag_name::${TAG}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v1
+        with:
+          version: latest
+          args: release --rm-dist --timeout=1h
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.prepare.outputs.tag_name }}
+
+      - name: set up buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          version: latest
+      
+      - name: login to dockerhub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+
+      - name: build (and publish) main image
+        env:
+          # fork friendly ^^
+          DOCKER_REPO: ${{ secrets.DOCKER_REPO }}
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64,linux/arm/v7 \
+            --build-arg VERSION=${{ steps.prepare.outputs.tag_name }} \
+            --push \
+            -t ${DOCKER_REPO:-dkron/dkron}:${{ steps.prepare.outputs.tag_name }} \
+            -t ${DOCKER_REPO:-dkron/dkron}:latest \
+            -f Dockerfile.hub \
+            .

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,9 @@ builds:
     goarch:
       - amd64
       - arm64
+      - arm
+    goarm:
+      - 7
     ldflags:
       - -s -w
 
@@ -33,6 +36,9 @@ builds:
     goarch:
       - amd64
       - arm64
+      - arm
+    goarm:
+      - 7
     ldflags:
       - -s -w
 
@@ -49,6 +55,9 @@ builds:
     goarch:
       - amd64
       - arm64
+      - arm
+    goarm:
+      - 7
     ldflags:
       - -s -w
 
@@ -65,6 +74,9 @@ builds:
     goarch:
       - amd64
       - arm64
+      - arm
+    goarm:
+      - 7
     ldflags:
       - -s -w
 
@@ -81,6 +93,9 @@ builds:
     goarch:
       - amd64
       - arm64
+      - arm
+    goarm:
+      - 7
     ldflags:
       - -s -w
   
@@ -97,6 +112,9 @@ builds:
     goarch:
       - amd64
       - arm64
+      - arm
+    goarm:
+      - 7
     ldflags:
       - -s -w
 
@@ -112,6 +130,9 @@ builds:
     goarch:
       - amd64
       - arm64
+      - arm
+    goarm:
+      - 7
     ldflags:
       - -s -w -X github.com/distribworks/dkron/v3/dkron.Version={{.Version}} -X github.com/distribworks/dkron/v3/dkron.Codename=merichuas
 
@@ -155,19 +176,3 @@ changelog:
     - '^docs:'
     - '^test:'
     - '^Merge pull request'
-
-dockers:
-  -
-    dockerfile: Dockerfile.hub
-    binaries:
-      - dkron
-      - dkron-executor-http
-      - dkron-executor-shell
-      - dkron-processor-syslog
-      - dkron-processor-log
-      - dkron-processor-files
-      - dkron-processor-fluent
-    image_templates:
-      - "dkron/dkron:latest"
-      - "dkron/dkron:{{ .Tag }}"
-      - "dkron/dkron:v{{ .Major }}"

--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -1,5 +1,7 @@
-FROM alpine
+# syntax=docker/dockerfile:1.0-experimental
+FROM alpine:3.11
 LABEL maintainer="Victor Castell <victor@victorcastell.com>"
+ARG TARGETPLATFORM
 
 RUN set -x \
 	&& buildDeps='bash ca-certificates openssl tzdata' \
@@ -12,8 +14,8 @@ EXPOSE 8080 8946
 ENV SHELL /bin/bash
 WORKDIR /opt/local/dkron
 
-COPY dkron .
-COPY dkron-* ./
+RUN --mount=target=/build tar xf /build/dist/dkron_*_$(echo ${TARGETPLATFORM} | tr '/' '_' | sed -e 's/arm_/arm/').tar.gz
+
 ENTRYPOINT ["/opt/local/dkron/dkron"]
 
 CMD ["--help"]


### PR DESCRIPTION
* Added release.yml workflow to run goreleaser and docker build/push only for tags
* Excluded tags from main.yml workflow (as tags should have been tested when pushed to the branch and avoids re-running workflows on the same commits)
* Removed docker build from goreleaser to separate step using `buildkit` -> allows for multi-arch builds -> GoReleaser has had this open 2 years https://github.com/goreleaser/goreleaser/issues/530 and it's still about the previous way (building each image and bundling the `docker manifest`), buildkit does it all in one go
* `scripts/release` no longer required, but left in case you want to do some manual release
* added arm/v7 build (for raspberry pi)


```
➜  dkron git:(fopina-patch-ga) docker run --rm dkron/dkron version
Name: Dkron
Version: 3.0.2
Codename: merichuas
Agent Protocol: 5 (Understands back to: 2)
➜  dkron git:(fopina-patch-ga) ssh sfpi docker run --rm dkron/dkron version
standard_init_linux.go:211: exec user process caused "exec format error"
➜  dkron git:(fopina-patch-ga) docker run --rm fopina/dkron:v3.0.2-12 version
Name: Dkron
Version: 3.0.2-12
Codename: merichuas
Agent Protocol: 5 (Understands back to: 2)
➜  dkron git:(fopina-patch-ga) ssh sfpi docker run --rm fopina/dkron:v3.0.2-12 version
Name: Dkron
Version: 3.0.2-12
Codename: merichuas
Agent Protocol: 5 (Understands back to: 2)
```

Left a few "fork friendly" items in workflow that won't affect dkron/dkron and make it easy to release patched versions from forks :D but we remove of course, if you prefer.
