### PR TITLE
busyhandler execution sorting

### DIFF
--- a/dkron/api.go
+++ b/dkron/api.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"sort"
 
 	"github.com/gin-contrib/expvar"
 	"github.com/gin-gonic/gin"
@@ -350,6 +351,10 @@ func (h *HTTPTransport) busyHandler(c *gin.Context) {
 	for _, e := range exs {
 		executions = append(executions, NewExecutionFromProto(e))
 	}
+
+	sort.SliceStable(executions, func(i, j int) bool {
+		return executions[i].StartedAt.Before(executions[j].StartedAt)
+	})
 
 	renderJSON(c, http.StatusOK, executions)
 }


### PR DESCRIPTION
Currently, busyHandler does no sorting, and the web UI doesn't either.
The result is a page where it is hard to follow any output as executions keep switching order:
![Peek 2020-05-25 00-11](https://user-images.githubusercontent.com/636320/82768997-47e18b00-9e2a-11ea-881b-cd98eb54342e.gif)

Sorting can be done both in the UI or in the busyHandler method.
In the UI it probably saves that (small yet existing) processing from dkron server, but then it shouldn't return an array.  
As an API consumer I expect a JSON array response to have some sort of order (usually, from a DB, it would be the cheapest order, the insertion order).
Regardless of the sorting criteria, the same request with the same set of results should always have the same order.
So I'd say it could make sense to leave the UI to order the response but turn it into a mapping/hash (`execution_name: execution`) or simply sort in `busyHandler` with some common criteria such as `jobName` or `startTime`.

I chose the latter in this PR, let me know if you'd rather have another approach.

End result:

![Peek 2020-05-25 01-49](https://user-images.githubusercontent.com/636320/82768998-49ab4e80-9e2a-11ea-913f-e2577215adb9.gif)
