### PR TITLE
feat: Parse retry-join addresses with sockaddr templates

### DIFF
--- a/dkron/retry_join.go
+++ b/dkron/retry_join.go
@@ -83,7 +83,12 @@ func (r *retryJoiner) retryJoin() error {
 				}
 
 			default:
-				addrs = append(addrs, addr)
+				ipAddr, err := ParseSingleIPTemplate(addr)
+				if err != nil {
+					log.WithField("addr", addr).WithError(err).Error("agent: Error parsing retry-join ip template")
+					continue
+				}
+				addrs = append(addrs, ipAddr)
 			}
 		}
 

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -1,9 +1,9 @@
 scripts/run agent --server --node-name=node1 --log-level=debug --bootstrap-expect=3
 
-scripts/run agent --server --node-name=node2 --bind-addr=0.0.0.0:8947 \
+scripts/run agent --server --node-name=node2 --bind-addr={{GetPrivateIP}}:8947 \
    --rpc-port=6869 --data-dir=node2.data --http-addr=:8081 \
-   --join=127.0.0.1:8946 --log-level=debug --bootstrap-expect=3
+   --retry-join={{GetPrivateIP}}:8946 --log-level=debug --bootstrap-expect=3
 
-scripts/run agent --server --node-name=node3 --bind-addr=0.0.0.0:8948 \
+scripts/run agent --server --node-name=node3 --bind-addr={{GetPrivateIP}}:8948 \
    --rpc-port=6870 --data-dir=node3.data --http-addr=:8082 \
-   --join=127.0.0.1:8946 --log-level=debug --bootstrap-expect=3
+   --retry-join={{GetPrivateIP}}:8946 --log-level=debug --bootstrap-expect=3


### PR DESCRIPTION
Also modify the example cluster script

Fixes https://github.com/distribworks/dkron/issues/782