### PR TITLE
fix: processFilteredNodes no nodes on no tag

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -734,9 +734,8 @@ func (a *Agent) processFilteredNodes(job *Job) (map[string]string, map[string]st
 			}
 			cans = f
 		}
-		if len(cans) > 0 {
-			candidates = append(candidates, cans)
-		}
+
+		candidates = append(candidates, cans)
 	}
 
 	// The final result will be the intersection of all candidates.
@@ -757,7 +756,11 @@ func (a *Agent) processFilteredNodes(job *Job) (map[string]string, map[string]st
 		for _, m := range a.serf.Members() {
 			if n == m.Name {
 				// If the server is missing the rpc_addr tag, default to the serf advertise addr
-				nodes[n] = m.Tags["rpc_addr"]
+				if addr, ok := m.Tags["rpc_addr"]; ok {
+					nodes[n] = addr
+				} else {
+					nodes[n] = m.Addr.String()
+				}
 			}
 		}
 	}

--- a/dkron/agent_test.go
+++ b/dkron/agent_test.go
@@ -120,7 +120,10 @@ func Test_processFilteredNodes(t *testing.T) {
 	c.NodeName = "test1"
 	c.Server = true
 	c.LogLevel = logLevel
-	c.Tags = map[string]string{"tag": "test"}
+	c.Tags = map[string]string{
+		"tag":    "test",
+		"region": "global",
+	}
 	c.DevMode = true
 	c.DataDir = dir
 
@@ -137,8 +140,9 @@ func Test_processFilteredNodes(t *testing.T) {
 	c.Server = true
 	c.LogLevel = logLevel
 	c.Tags = map[string]string{
-		"tag":   "test",
-		"extra": "tag",
+		"tag":    "test",
+		"extra":  "tag",
+		"region": "global",
 	}
 	c.DevMode = true
 	c.DataDir = dir
@@ -158,8 +162,9 @@ func Test_processFilteredNodes(t *testing.T) {
 	c.Server = false
 	c.LogLevel = logLevel
 	c.Tags = map[string]string{
-		"tag":   "test_client",
-		"extra": "tag",
+		"tag":    "test_client",
+		"extra":  "tag",
+		"region": "global",
 	}
 	c.DevMode = true
 	c.DataDir = dir
@@ -172,7 +177,6 @@ func Test_processFilteredNodes(t *testing.T) {
 	job := &Job{
 		Name: "test_job_1",
 		Tags: map[string]string{
-			"foo": "bar:1",
 			"tag": "test:2",
 		},
 	}
@@ -221,6 +225,48 @@ func Test_processFilteredNodes(t *testing.T) {
 
 	assert.Len(t, nodes, 1)
 	assert.Contains(t, nodes, "test3")
+
+	job5 := &Job{
+		Name: "test_job_5",
+		Tags: map[string]string{
+			"tag": "no_tag",
+		},
+	}
+
+	nodes, _, err = a1.processFilteredNodes(job5)
+	require.NoError(t, err)
+
+	assert.Len(t, nodes, 0)
+
+	job6 := &Job{
+		Name: "test_job_6",
+		Tags: map[string]string{
+			"foo": "bar:1",
+			"tag": "test:2",
+		},
+	}
+
+	nodes, tags, err = a1.processFilteredNodes(job6)
+	require.NoError(t, err)
+
+	assert.Len(t, nodes, 0)
+	assert.Equal(t, tags["tag"], "test")
+
+	job7 := &Job{
+		Name: "test_job_7",
+		Tags: map[string]string{
+			"tag":   "test:2",
+			"extra": "tag:2",
+		},
+	}
+
+	nodes, tags, err = a1.processFilteredNodes(job7)
+	require.NoError(t, err)
+
+	assert.Contains(t, nodes, "test2")
+	assert.Len(t, nodes, 1)
+	assert.Equal(t, tags["tag"], "test")
+	assert.Equal(t, tags["extra"], "tag")
 
 	a1.Stop()
 	a2.Stop()

--- a/go.sum
+++ b/go.sum
@@ -713,6 +713,7 @@ google.golang.org/protobuf v1.21.0 h1:qdOKuR/EIArgaWNjetjgTzgVTAZ+S/WXVrq9HW9zim
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.22.0 h1:cJv5/xdbk1NnMPR1VP9+HU6gupuG9MLBoH1r6RHZ2MY=
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=


### PR DESCRIPTION
processFilteredNodes should not return nodes when the specified tags are not found.

This PR also enforce that the returned nodes will have all specified tags, because mixing groups could lead to unexpected results when using  counts.

Fixes #761 