### PR TITLE
Fix: free s.Cron on proper opportunity to avoid unexpected crash.

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -240,6 +240,7 @@ func (a *Agent) Stop() error {
 
 	if a.config.Server && a.sched.Started {
 		a.sched.Stop()
+		a.sched.ClearCron()
 	}
 
 	if err := a.serf.Leave(); err != nil {


### PR DESCRIPTION
Ignore the running jobs and make `s.Cron` to nil may cause whole process crashed.

After digging, I found that `s.Cron` will be `nil` when `revokeLeadership()` be called, but you will never know when `revokeLeaderShip()` will be call. 

Maybe when calling `revokeLeaderShip()`, there is also one job is still running (they are in different goroutines, they are both running), it needs `s.Cron`, but before it utilize `s.Cron`, `s.Cron` has been freed by `revokeLeadership()`, then the whole prcess will crash.

Below is the crash point, `s.Cron.Entries()`:

```go
// GetEntry returns a scheduler entry from a snapshot in
// the current time, and whether or not the entry was found.
func (s *Scheduler) GetEntry(jobName string) (cron.Entry, bool) {
	for _, e := range s.Cron.Entries() {
		j, _ := e.Job.(*Job)
		if j.Name == jobName {
			return e, true
		}
	}
	return cron.Entry{}, false
}
```