### PR TITLE
Update installation.md

### DIFF
--- a/website/content/basics/installation.md
+++ b/website/content/basics/installation.md
@@ -66,7 +66,7 @@ Dkron uses the local filesystem for storing the embedded database to store its o
 To persist your data outside of the container and make it available for use between container launches we can mount a local path inside our container.
 
 ```
-docker run -d -p 8080:8080 -v ~/dkron.data:/dkron.data --name dkron dkron/dkron agent --server --bootstrap-expect=1
+docker run -d -p 8080:8080 -v ~/dkron.data:/dkron.data --name dkron dkron/dkron agent --server --bootstrap-expect=1 --data-dir=/dkron.data
 ```
 
 Now when you launch your container we are mounting that folder from our local filesystem into the container.


### PR DESCRIPTION
I found that there is a missing parameter in [Mounting a mapped file storage volume instruction](https://dkron.io/basics/installation/#mounting-a-mapped-file-storage-volume) section to persist data when mounted in docker vloume. The arguments `data-dir` is missing from the command. 