### PR TITLE
Make Execute() wait for initialization of status gRPC server before use

### DIFF
--- a/plugin/executor.go
+++ b/plugin/executor.go
@@ -37,11 +37,16 @@ func (p *ExecutorPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBrok
 	return &ExecutorClient{client: types.NewExecutorClient(c), broker: broker}, nil
 }
 
+type Broker interface {
+	NextId() uint32
+	AcceptAndServe(id uint32, s func([]grpc.ServerOption) *grpc.Server)
+}
+
 // Here is the gRPC client that GRPCClient talks to.
 type ExecutorClient struct {
 	// This is the real implementation
 	client types.ExecutorClient
-	broker *plugin.GRPCBroker
+	broker Broker
 }
 
 func (m *ExecutorClient) Execute(args *types.ExecuteRequest, cb StatusHelper) (*types.ExecuteResponse, error) {

--- a/plugin/executor_test.go
+++ b/plugin/executor_test.go
@@ -1,0 +1,47 @@
+package plugin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/distribworks/dkron/v3/plugin/types"
+	dktypes "github.com/distribworks/dkron/v3/plugin/types"
+	grpc "google.golang.org/grpc"
+)
+
+type MockedExecutor struct{}
+
+func (m *MockedExecutor) Execute(ctx context.Context, in *types.ExecuteRequest, opts ...grpc.CallOption) (*types.ExecuteResponse, error) {
+	resp := &dktypes.ExecuteResponse{}
+	return resp, nil
+}
+
+type MockedStatusHelper struct{}
+
+func (m MockedStatusHelper) Update([]byte, bool) (int64, error) {
+	return 0, nil
+}
+
+type MockedBroker struct{}
+
+func (m *MockedBroker) AcceptAndServe(id uint32, s func([]grpc.ServerOption) *grpc.Server) {
+}
+
+func (m *MockedBroker) NextId() uint32 {
+	return 0
+}
+
+func TestExecuteDoesNotPanicIfGRPCIsNotInitializedOnTime(t *testing.T) {
+	var brokerMock MockedBroker
+	var execMock MockedExecutor
+	execClient := ExecutorClient{
+		client: &execMock,
+		broker: &brokerMock,
+	}
+
+	var requestStub dktypes.ExecuteRequest
+	var statusHelperMock MockedStatusHelper
+	assert.NotPanics(t, func() { execClient.Execute(&requestStub, statusHelperMock) })
+}


### PR DESCRIPTION
Attempt to fix #828 .
I have no decent way to test whether this fixes the problem, so would be great if someone having issues could test this.