### PR TITLE
fix: Server crash when adding new job

### DIFF
--- a/dkron/scheduler_test.go
+++ b/dkron/scheduler_test.go
@@ -41,7 +41,7 @@ func TestSchedule(t *testing.T) {
 	assert.True(t, sched.Started)
 	assert.Len(t, sched.Cron.Entries(), 1)
 
-	sched.Cron.Remove("cron_job")
+	sched.Cron.Remove(1)
 	assert.Len(t, sched.Cron.Entries(), 0)
 
 	sched.Stop()

--- a/dkron/scheduler_test.go
+++ b/dkron/scheduler_test.go
@@ -40,6 +40,10 @@ func TestSchedule(t *testing.T) {
 
 	assert.True(t, sched.Started)
 	assert.Len(t, sched.Cron.Entries(), 1)
+
+	sched.Cron.Remove("cron_job")
+	assert.Len(t, sched.Cron.Entries(), 0)
+
 	sched.Stop()
 }
 


### PR DESCRIPTION
This was causing a crash because of "map" not being concurrent safe. sync.Map provides a better alternative.

fixes #819 