### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
I was just about to open a PR to add fetch-depth after seeing the release changelog today
I used it the first time myself when master was v1 (and depth was not 1 by default)

Probably worth pinning checkout to `v2` to avoid future breaking changes like this (as suggested in the [issue](https://github.com/goreleaser/goreleaser-action/issues/56))

