### PR TITLE
fix: How errors are handled in the AgentRun call

### DIFF
--- a/dkron/grpc_agent.go
+++ b/dkron/grpc_agent.go
@@ -63,9 +63,6 @@ func (as *AgentServer) AgentRun(req *types.AgentRunRequest, stream types.Agent_A
 
 	jex := job.Executor
 	exc := job.ExecutorConfig
-	if jex == "" {
-		return errors.New("grpc_agent: No executor defined, nothing to do")
-	}
 
 	// Send the first update with the initial execution state to be stored in the server
 	execution.StartedAt = ptypes.TimestampNow()
@@ -75,6 +72,10 @@ func (as *AgentServer) AgentRun(req *types.AgentRunRequest, stream types.Agent_A
 		Execution: execution,
 	}); err != nil {
 		return err
+	}
+
+	if jex == "" {
+		return errors.New("grpc_agent: No executor defined, nothing to do")
 	}
 
 	// Check if executor exists

--- a/dkron/grpc_client.go
+++ b/dkron/grpc_client.go
@@ -421,11 +421,11 @@ func (grpcc *GRPCClient) AgentRun(addr string, job *proto.Job, execution *proto.
 			return nil
 		}
 
-		// Error receiving from stream
+		// Error received from the stream
 		if err != nil {
 			// At this point the execution status will be unknown, set the FinshedAt time and an explanatory message
 			execution.FinishedAt = ptypes.TimestampNow()
-			execution.Output = []byte(ErrBrokenStream.Error())
+			execution.Output = []byte(err.Error())
 
 			log.WithError(err).Error(ErrBrokenStream)
 


### PR DESCRIPTION
Was a bit confusing specially in the case of no defined executor in a job.