### PR TITLE
Use correct wrapping and monospace font for execution's output

### DIFF
--- a/ui/src/executions/BusyList.tsx
+++ b/ui/src/executions/BusyList.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { List, Datagrid, TextField, DateField } from 'react-admin';
 
 export const OutputPanel = ({ id, record, resource }: any) => (
-    <div dangerouslySetInnerHTML={{ __html: record.output }} />
+    <div class="execution-output" dangerouslySetInnerHTML={{ __html: record.output }} />
 );
 
 export const BusyList = (props: any) => (

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -11,3 +11,9 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.execution-output {
+  white-space: break-spaces;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -16,4 +16,6 @@ code {
   white-space: break-spaces;
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
+  max-height: 300px;
+  overflow: auto;
 }


### PR DESCRIPTION
Hi,
I like the new UI and using it everyday, but I think we missed something important - correct command output.
For example, I've created job that shows recursively directory structure.

In current stable version it looks not very useful:
<img src="https://cdn.weblab.pro/winiy.png" />

I've applied some CSS changes to fix it:
<img src="https://cdn.weblab.pro/vmewg.png" />

I've added `max-height` too to prevent problems with huge outputs, but I'm not sure that I used right value for such rule.

@victorcoder what do you think about these changes?