### PR TITLE
fix panic on recovering cluster (with peers.json)

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -327,7 +327,11 @@ func (a *Agent) setupRaft() error {
 			if err != nil {
 				return fmt.Errorf("recovery failed to parse peers.json: %v", err)
 			}
-			tmpFsm := newFSM(nil, nil)
+			store, err := NewStore()
+			if err != nil {
+				log.WithError(err).Fatal("dkron: Error initializing store")
+                        }
+			tmpFsm := newFSM(store, nil)
 			if err := raft.RecoverCluster(config, tmpFsm,
 				logStore, stableStore, snapshots, transport, configuration); err != nil {
 				return fmt.Errorf("recovery failed: %v", err)


### PR DESCRIPTION
This is an attempt to fix #767

Not entirely sure if this is the proper way to initialize the store but I tested locally and seems to work

* Spun up cluster with 3 server nodes, added jobs and executed them (for more data in the raft log).
* Killed all 3 and restarted just one - leadership not acquired as missing quorum
* Added that single node to peers.json and restarted it - leadership acquired and all the data shown