### PR TITLE
configurable job timeout

### DIFF
--- a/website/content/usage/executors/shell.md
+++ b/website/content/usage/executors/shell.md
@@ -14,6 +14,7 @@ shell: Run this command using a shell environment
 command: The command to run
 env: Env vars separated by comma
 cwd: Chdir before command run
+timeout: Force kill job after specified time. Format: https://golang.org/pkg/time/#ParseDuration. Default: 24h
 ```
 
 Example
@@ -25,7 +26,8 @@ Example
       "shell": "true",
       "command": "my_command",
       "env": "ENV_VAR=va1,ANOTHER_ENV_VAR=var2",
-      "cwd": "/app"
+      "cwd": "/app",
+      "timeout": "24h",
   }
 }
 ```


### PR DESCRIPTION
This is what we use in real life. Sometimes jobs are stuck by any reason, and we simply expect them to finish in a specified time. If not, we kill it and raise monitoring alert that job wasn't finished in expected time.
In our case we even not allow running jobs without explicitly defined timeout. Here in PR I decided just to default to 24h in case timeout is not defined for a job.

Monitoring will come in future PRs