### PR TITLE
Configurable job timeout 

### DIFF
--- a/dkron/api_test.go
+++ b/dkron/api_test.go
@@ -236,6 +236,18 @@ func TestAPIJobCreateUpdateValidationBadTimezone(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
+func TestAPIJobCreateUpdateValidationBadShellExecutorTimeout(t *testing.T) {
+	resp := postJob(t, "8099", []byte(`{
+		"name": "testjob",
+		"schedule": "@every 1m",
+		"executor": "shell",
+		"executor_config": {"command": "date", "timeout": "foreverandever"},
+		"disabled": true
+	}`))
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
 func TestAPIGetNonExistentJobReturnsNotFound(t *testing.T) {
 	port := "8096"
 	baseURL := fmt.Sprintf("http://localhost:%s/v1", port)

--- a/dkron/job.go
+++ b/dkron/job.go
@@ -357,6 +357,13 @@ func (j *Job) Validate() error {
 		return err
 	}
 
+	if j.Executor == "shell" && j.ExecutorConfig["timeout"] != "" {
+		_, err := time.ParseDuration(j.ExecutorConfig["timeout"])
+		if err != nil {
+			return fmt.Errorf("Error parsing job timeout value")
+		}
+	}
+
 	return nil
 }
 

--- a/website/content/usage/executors/shell.md
+++ b/website/content/usage/executors/shell.md
@@ -14,6 +14,7 @@ shell: Run this command using a shell environment
 command: The command to run
 env: Env vars separated by comma
 cwd: Chdir before command run
+timeout: Force kill job after specified time. Format: https://golang.org/pkg/time/#ParseDuration.
 ```
 
 Example
@@ -25,7 +26,8 @@ Example
       "shell": "true",
       "command": "my_command",
       "env": "ENV_VAR=va1,ANOTHER_ENV_VAR=var2",
-      "cwd": "/app"
+      "cwd": "/app",
+      "timeout": "24h"
   }
 }
 ```


### PR DESCRIPTION
Sometimes jobs may stuck by any reason, and we expect them to finish in a specified time.
Default behaviour is not do anything.

