### PR TITLE
feat(ui): add a filter on disabled state

### DIFF
--- a/dkron/api.go
+++ b/dkron/api.go
@@ -179,6 +179,7 @@ func (h *HTTPTransport) jobsHandler(c *gin.Context) {
 			Order:    order,
 			Query:    q,
 			Status:   c.Query("status"),
+			Disabled: c.Query("disabled"),
 		},
 	)
 	if err != nil {
@@ -340,7 +341,7 @@ func (h *HTTPTransport) executionsHandler(c *gin.Context) {
 		return
 	}
 
-	executions, err := h.agent.Store.GetExecutions(job.Name, 
+	executions, err := h.agent.Store.GetExecutions(job.Name,
 		&ExecutionOptions{
 			Sort:     sort,
 			Order:    order,

--- a/dkron/store.go
+++ b/dkron/store.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -45,6 +46,7 @@ type JobOptions struct {
 	Order    string
 	Query    string
 	Status   string
+	Disabled string
 }
 
 // ExecutionOptions additional options like "Sort" will be ready for JSON marshall
@@ -328,7 +330,8 @@ func (s *Store) GetJobs(options *JobOptions) ([]*Job, error) {
 		if options == nil ||
 			(options.Metadata == nil || len(options.Metadata) == 0 || s.jobHasMetadata(job, options.Metadata)) &&
 				(options.Query == "" || strings.Contains(job.Name, options.Query)) &&
-				(options.Status == "" || job.Status == options.Status) {
+				(options.Status == "" || job.Status == options.Status) &&
+				(options.Disabled == "" || strconv.FormatBool(job.Disabled) == options.Disabled) {
 
 			jobs = append(jobs, job)
 		}

--- a/ui/src/jobs/JobList.tsx
+++ b/ui/src/jobs/JobList.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { 
+import {
     Datagrid,
     TextField,
     NumberField,
@@ -10,7 +10,8 @@ import {
     TextInput,
     List,
     SelectInput,
-    BulkDeleteButton
+    BulkDeleteButton,
+    BooleanInput
 } from 'react-admin';
 import { Fragment } from 'react';
 import BulkRunButton from "./BulkRunButton"
@@ -24,6 +25,7 @@ const JobFilter = (props: any) => (
             { id: 'success', name: 'Success' },
             { id: 'failed', name: 'Failed' },
         ]} />
+        <BooleanInput source="disabled"/>
     </Filter>
 );
 


### PR DESCRIPTION
Following https://github.com/distribworks/dkron/issues/912, add a new filter on the jobs page to only show disabled or enabled jobs.