### PR TITLE
Improve tests for http executor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15
+FROM golang:1.16
 LABEL maintainer="Victor Castell <victor@victorcastell.com>"
 
 EXPOSE 8080 8946

--- a/builtin/bins/dkron-executor-http/http_test.go
+++ b/builtin/bins/dkron-executor-http/http_test.go
@@ -1,51 +1,103 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/distribworks/dkron/v3/plugin/types"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestExecute(t *testing.T) {
-	pa := &types.ExecuteRequest{
-		JobName: "testJob",
-		Config: map[string]string{
-			"method":     "GET",
-			"url":        "https://httpbin.org/get",
-			"expectCode": "200",
-			"debug":      "true",
-		},
-	}
-	http := &HTTP{}
-	output, err := http.Execute(pa, nil)
-	fmt.Println(string(output.Output))
-	fmt.Println(err)
-	if err != nil {
-		t.Fatal(err)
-	}
+func newTestServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("Path: %s", r.URL.Path)
+		switch r.URL.Path {
+
+		// Handlers to control known HTTP response codes
+		case "/200":
+			w.WriteHeader(200)
+			return
+		case "/400":
+			w.WriteHeader(400)
+			return
+		case "/401":
+			w.WriteHeader(401)
+			return
+		case "/404":
+			w.WriteHeader(404)
+			return
+		case "/500":
+			w.WriteHeader(500)
+			return
+
+		// Return a predefined string as the response body
+		case "/hello":
+			w.Write([]byte("hello"))
+			return
+
+		// Echo POST body back to request
+		case "/echo":
+			if r.Method == http.MethodPost {
+				in, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					w.WriteHeader(500)
+					return
+				}
+				r.Body.Close()
+				w.Write(in)
+				w.WriteHeader(200)
+				return
+			}
+		}
+
+	}))
 }
 
-func TestExecutePost(t *testing.T) {
-	pa := &types.ExecuteRequest{
-		JobName: "testJob",
-		Config: map[string]string{
-			"method":     "POST",
-			"url":        "https://httpbin.org/post",
-			"body":       "{\"hello\":11}",
-			"headers":    "[\"Content-Type:application/json\"]",
-			"expectCode": "200",
-			"expectBody": "",
-			"debug":      "true",
-		},
+func TestExecute(t *testing.T) {
+	ts := newTestServer()
+	defer ts.Close()
+
+	tests := []struct {
+		name    string
+		config  map[string]string
+		want    []byte
+		wantErr bool
+	}{
+		{"Expected 200", map[string]string{"method": "GET", "url": fmt.Sprintf("%s/200", ts.URL), "expectCode": "200"}, []byte{}, false},
+		{"Expected 400", map[string]string{"method": "GET", "url": fmt.Sprintf("%s/400", ts.URL), "expectCode": "400"}, []byte{}, false},
+		{"Expected 404", map[string]string{"method": "GET", "url": fmt.Sprintf("%s/404", ts.URL), "expectCode": "404"}, []byte{}, false},
+		{"Unexpected 400 is error", map[string]string{"method": "GET", "url": fmt.Sprintf("%s/400", ts.URL), "expectCode": "200"}, []byte{}, true},
+		{"Empty URL is error", map[string]string{"method": "GET", "url": "", "expectCode": "200"}, []byte{}, true},
+		{"Empty method is error", map[string]string{"method": "", "url": fmt.Sprintf("%s/200", ts.URL), "expectCode": "200"}, []byte{}, true},
+		{"Expected GET Response", map[string]string{"method": "GET", "url": fmt.Sprintf("%s/hello", ts.URL), "expectCode": "200"}, []byte("hello"), false},
+		{"Expected POST Response", map[string]string{"method": "POST", "url": fmt.Sprintf("%s/echo", ts.URL), "body": "this is a post body", "expectBody": "this is a post body", "expectCode": "200"}, []byte("this is a post body"), false},
+		{"Unexpected POST Response is error", map[string]string{"method": "POST", "url": fmt.Sprintf("%s/echo", ts.URL), "body": "this is a post body", "expectBody": "not this", "expectCode": "200"}, []byte("this is a post body"), true},
 	}
-	http := &HTTP{}
-	output, err := http.Execute(pa, nil)
-	fmt.Println(string(output.Output))
-	fmt.Println(err)
-	if err != nil {
-		t.Fatal(err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			http := &HTTP{}
+			pa := &types.ExecuteRequest{
+				JobName: tt.name,
+				Config:  tt.config,
+			}
+			// Err is always nil from http.Execute()
+			got, _ := http.Execute(pa, nil)
+			if (got.Error != "") != tt.wantErr {
+				t.Errorf("HTTP.Execute().Error = %v, wantErr %v", got.Error, tt.wantErr)
+				return
+			}
+
+			if !bytes.Equal(got.Output, tt.want) {
+				t.Errorf("HTTP.Execute().Output = %s, want %s", got.Output, tt.want)
+			}
+
+		})
 	}
 }
 


### PR DESCRIPTION
While troubleshooting issues with HTTP jobs, I noticed that test cases that I expected to fail, were not causing the test to fail. I dug in and realized that the errors from the output were not being checked. The returned error was being checked, but this is hard coded to nil in the return so it offers very little value.

This adds some common test cases for the HTTP executor and ensures that many input validations return an error and known good configurations work as expected.

This also updates the Dockerfile to go 1.16 because 1.15 does not include go:embed and was causing `make test` to fail.

New Test Output:
```
--- PASS: TestExecute (0.03s)
    --- PASS: TestExecute/Expected_200 (0.01s)
    --- PASS: TestExecute/Expected_400 (0.00s)
    --- PASS: TestExecute/Expected_404 (0.00s)
    --- PASS: TestExecute/Unexpected_400_is_error (0.00s)
    --- PASS: TestExecute/Empty_URL_is_error (0.00s)
    --- PASS: TestExecute/Empty_method_is_error (0.00s)
    --- PASS: TestExecute/Expected_GET_Response (0.00s)
    --- PASS: TestExecute/Expected_POST_Response (0.02s)
    --- PASS: TestExecute/Unexpected_POST_Response_is_error (0.00s)
```