### PR TITLE
Clarify that default is for all nodes run each job

### DIFF
--- a/website/content/basics/getting-started.md
+++ b/website/content/basics/getting-started.md
@@ -17,7 +17,7 @@ Dkron clusters have a leader, the leader is responsible of starting job executio
 
 Any Dkron agent or server acts as a cluster member and it's available to run scheduled jobs.
 
-You can choose whether a job is run on a node or nodes by specifying tags and a count of target nodes having this tag do you want a job to run. This gives an unprecedented level of flexibility in runnig jobs across a cluster of any size and with any combination of machines you need.
+Default is for all nodes to execute each job. You can control what nodes run a job by specifying tags and a count of target nodes having this tag. This gives an unprecedented level of flexibility in runnig jobs across a cluster of any size and with any combination of machines you need.
 
 All the execution responses will be gathered by the scheduler and stored in the database.
 

--- a/website/content/usage/target-nodes-spec.md
+++ b/website/content/usage/target-nodes-spec.md
@@ -5,7 +5,7 @@ weight: 10
 
 ## Target nodes spec
 
-Dkron has the ability to run jobs in specific nodes by leveraging the use of tags. You can choose whether a job is run on a node or group of nodes by specifying tags and a count of target nodes having this tag do you want a job to run.
+Default is for all nodes to execute each job. Dkron has the ability to run jobs in specific nodes by leveraging the use of tags. You can choose whether a job is run on a node or group of nodes by specifying tags and a count of target nodes having this tag do you want a job to run.
 
 The target node syntax is:
     
@@ -30,6 +30,8 @@ To achieve this Nodes and Jobs have tags, for example, having a node with the fo
 ```
 
 {{% alert info %}}**Tip:** You can specify tags for nodes in the dkron config file or in the command line using `--tags` parameter{{% /alert %}}
+
+In case there is no matching nodes with the specified tags, the job will not run.
 
 Following some examples using different tag combinations:
 
@@ -102,6 +104,3 @@ There is no limit in the tags that a job can have but having a Job with several 
 ```
 
 Will try to run the job in nodes that have all specified tags and using the lowest count. In the last example, it will run in **one** node having `"my_role": "web"` and `"role": "dkron"` tag, even if there is more than one node with these tags.
-
-* In case there is no matching nodes with the specified tags, the job will not run
-* In case no tags are specified for a job it will run in all nodes in the cluster


### PR DESCRIPTION
As can be seen in #935, I had not understood that default was for jobs to be executed by all nodes, when there is no tagging to say differently. This PR updates the docs to make this default clear. I believe that if this PR had been applied, I would not have logged the issue in question.