### PR TITLE
Updated Go version on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15
+FROM golang:1.16
 LABEL maintainer="Victor Castell <victor@victorcastell.com>"
 
 EXPOSE 8080 8946


### PR DESCRIPTION
Dockerfile to use Go 1.16 in order to fix #944.