### PR TITLE
Overhaul logging to avoid package level var

### DIFF
--- a/cmd/leave.go
+++ b/cmd/leave.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/distribworks/dkron/v3/dkron"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +24,8 @@ var leaveCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var gc dkron.DkronGRPCClient
-		gc = dkron.NewGRPCClient(nil, nil)
+		log := logrus.NewEntry(logrus.New())
+		gc = dkron.NewGRPCClient(nil, nil, log)
 
 		if err := gc.Leave(ip); err != nil {
 			return err

--- a/cmd/raft.go
+++ b/cmd/raft.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/distribworks/dkron/v3/dkron"
 	"github.com/ryanuber/columnize"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +30,8 @@ var raftListCmd = &cobra.Command{
 	Short: "Command to list raft peers",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		gc := dkron.NewGRPCClient(nil, nil)
+		log := logrus.NewEntry(logrus.New())
+		gc := dkron.NewGRPCClient(nil, nil, log)
 
 		reply, err := gc.RaftGetConfiguration(ip)
 		if err != nil {
@@ -60,7 +62,8 @@ var raftRemovePeerCmd = &cobra.Command{
 	Short: "Command to list raft peers",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		gc := dkron.NewGRPCClient(nil, nil)
+		log := logrus.NewEntry(logrus.New())
+		gc := dkron.NewGRPCClient(nil, nil, log)
 
 		if err := gc.RaftRemovePeerByID(ip, peerID); err != nil {
 			return err

--- a/dkron/agent_test.go
+++ b/dkron/agent_test.go
@@ -3,6 +3,7 @@ package dkron
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"testing"
 	"time"
@@ -104,7 +105,7 @@ func TestAgentCommand_runForElection(t *testing.T) {
 	// Wait until a follower steps as leader
 	time.Sleep(2 * time.Second)
 	assert.True(t, (a2.IsLeader() || a3.IsLeader()))
-	log.Info(a3.IsLeader())
+	log.Println(a3.IsLeader())
 
 	a2.Stop()
 	a3.Stop()

--- a/dkron/config.go
+++ b/dkron/config.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"strconv"

--- a/dkron/dashboard.go
+++ b/dkron/dashboard.go
@@ -11,6 +11,7 @@ import (
 	"github.com/distribworks/dkron/v3/dkron/templates"
 	"github.com/gin-contrib/multitemplate"
 	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -97,13 +98,13 @@ func (a *Agent) dashboardExecutionsHandler(c *gin.Context) {
 		jobLocation = job.GetTimeLocation()
 	}
 
-	groups, byGroup, err := a.Store.GetGroupedExecutions(jobName, 
+	groups, byGroup, err := a.Store.GetGroupedExecutions(jobName,
 		&ExecutionOptions{
 			Timezone: jobLocation,
 		},
 	)
 	if err != nil {
-		log.Error(err)
+		a.logger.Error(err)
 	}
 
 	var count int
@@ -137,7 +138,7 @@ func (a *Agent) dashboardBusyHandler(c *gin.Context) {
 	c.HTML(http.StatusOK, "busy", data)
 }
 
-func mustLoadTemplate(path string) []byte {
+func mustLoadTemplate(path string, log *logrus.Entry) []byte {
 	f, err := templates.Templates.Open(path)
 	if err != nil {
 		log.Error(err)
@@ -155,31 +156,31 @@ func mustLoadTemplate(path string) []byte {
 
 // CreateMyRender returns a new custom multitemplate renderer
 // to use with Gin.
-func CreateMyRender() multitemplate.Render {
+func CreateMyRender(l *logrus.Entry) multitemplate.Render {
 	r := multitemplate.New()
 
-	status := mustLoadTemplate("/status.html.tmpl")
-	dash := mustLoadTemplate("/dashboard.html.tmpl")
+	status := mustLoadTemplate("/status.html.tmpl", l)
+	dash := mustLoadTemplate("/dashboard.html.tmpl", l)
 
 	r.AddFromStringsFuncs("index", funcMap(),
 		string(dash),
 		string(status),
-		string(mustLoadTemplate("/index.html.tmpl")))
+		string(mustLoadTemplate("/index.html.tmpl", l)))
 
 	r.AddFromStringsFuncs("jobs", funcMap(),
 		string(dash),
 		string(status),
-		string(mustLoadTemplate("/jobs.html.tmpl")))
+		string(mustLoadTemplate("/jobs.html.tmpl", l)))
 
 	r.AddFromStringsFuncs("executions", funcMap(),
 		string(dash),
 		string(status),
-		string(mustLoadTemplate("/executions.html.tmpl")))
+		string(mustLoadTemplate("/executions.html.tmpl", l)))
 
 	r.AddFromStringsFuncs("busy", funcMap(),
 		string(dash),
 		string(status),
-		string(mustLoadTemplate("/busy.html.tmpl")))
+		string(mustLoadTemplate("/busy.html.tmpl", l)))
 
 	return r
 }

--- a/dkron/grpc.go
+++ b/dkron/grpc.go
@@ -41,13 +41,15 @@ type DkronGRPCServer interface {
 // GRPCServer is the local implementation of the gRPC server interface.
 type GRPCServer struct {
 	proto.DkronServer
-	agent *Agent
+	agent  *Agent
+	logger *logrus.Entry
 }
 
 // NewGRPCServer creates and returns an instance of a DkronGRPCServer implementation
-func NewGRPCServer(agent *Agent) DkronGRPCServer {
+func NewGRPCServer(agent *Agent, logger *logrus.Entry) DkronGRPCServer {
 	return &GRPCServer{
-		agent: agent,
+		agent:  agent,
+		logger: logger,
 	}
 }
 
@@ -56,7 +58,7 @@ func (grpcs *GRPCServer) Serve(lis net.Listener) error {
 	grpcServer := grpc.NewServer()
 	proto.RegisterDkronServer(grpcServer, grpcs)
 
-	as := NewAgentServer(grpcs.agent)
+	as := NewAgentServer(grpcs.agent, grpcs.logger)
 	proto.RegisterAgentServer(grpcServer, as)
 	go grpcServer.Serve(lis)
 
@@ -80,7 +82,7 @@ func Encode(t MessageType, msg interface{}) ([]byte, error) {
 // This only works on the leader
 func (grpcs *GRPCServer) SetJob(ctx context.Context, setJobReq *proto.SetJobRequest) (*proto.SetJobResponse, error) {
 	defer metrics.MeasureSince([]string{"grpc", "set_job"}, time.Now())
-	log.WithFields(logrus.Fields{
+	grpcs.logger.WithFields(logrus.Fields{
 		"job": setJobReq.Job.Name,
 	}).Debug("grpc: Received SetJob")
 
@@ -102,7 +104,7 @@ func (grpcs *GRPCServer) SetJob(ctx context.Context, setJobReq *proto.SetJobRequ
 // This only works on the leader
 func (grpcs *GRPCServer) DeleteJob(ctx context.Context, delJobReq *proto.DeleteJobRequest) (*proto.DeleteJobResponse, error) {
 	defer metrics.MeasureSince([]string{"grpc", "delete_job"}, time.Now())
-	log.WithField("job", delJobReq.GetJobName()).Debug("grpc: Received DeleteJob")
+	grpcs.logger.WithField("job", delJobReq.GetJobName()).Debug("grpc: Received DeleteJob")
 
 	cmd, err := Encode(DeleteJobType, delJobReq)
 	if err != nil {
@@ -128,7 +130,7 @@ func (grpcs *GRPCServer) DeleteJob(ctx context.Context, delJobReq *proto.DeleteJ
 // GetJob loads the job from the datastore
 func (grpcs *GRPCServer) GetJob(ctx context.Context, getJobReq *proto.GetJobRequest) (*proto.GetJobResponse, error) {
 	defer metrics.MeasureSince([]string{"grpc", "get_job"}, time.Now())
-	log.WithField("job", getJobReq.JobName).Debug("grpc: Received GetJob")
+	grpcs.logger.WithField("job", getJobReq.JobName).Debug("grpc: Received GetJob")
 
 	j, err := grpcs.agent.Store.GetJob(getJobReq.JobName, nil)
 	if err != nil {
@@ -150,7 +152,7 @@ func (grpcs *GRPCServer) GetJob(ctx context.Context, getJobReq *proto.GetJobRequ
 // ExecutionDone saves the execution to the store
 func (grpcs *GRPCServer) ExecutionDone(ctx context.Context, execDoneReq *proto.ExecutionDoneRequest) (*proto.ExecutionDoneResponse, error) {
 	defer metrics.MeasureSince([]string{"grpc", "execution_done"}, time.Now())
-	log.WithFields(logrus.Fields{
+	grpcs.logger.WithFields(logrus.Fields{
 		"group": execDoneReq.Execution.Group,
 		"job":   execDoneReq.Execution.JobName,
 		"from":  execDoneReq.Execution.NodeName,
@@ -173,12 +175,12 @@ func (grpcs *GRPCServer) ExecutionDone(ctx context.Context, execDoneReq *proto.E
 
 	pbex := *execDoneReq.Execution
 	for k, v := range job.Processors {
-		log.WithField("plugin", k).Info("grpc: Processing execution with plugin")
+		grpcs.logger.WithField("plugin", k).Info("grpc: Processing execution with plugin")
 		if processor, ok := grpcs.agent.ProcessorPlugins[k]; ok {
 			v["reporting_node"] = grpcs.agent.config.NodeName
 			pbex = processor.Process(&plugin.ProcessorArgs{Execution: pbex, Config: v})
 		} else {
-			log.WithField("plugin", k).Error("grpc: Specified plugin not found")
+			grpcs.logger.WithField("plugin", k).Error("grpc: Specified plugin not found")
 		}
 	}
 
@@ -195,7 +197,7 @@ func (grpcs *GRPCServer) ExecutionDone(ctx context.Context, execDoneReq *proto.E
 	// Retrieve the fresh, updated job from the store to work on stored values
 	job, err = grpcs.agent.Store.GetJob(job.Name, nil)
 	if err != nil {
-		log.WithError(err).WithField("job", execDoneReq.Execution.JobName).Error("grpc: Error retrieving job from store")
+		grpcs.logger.WithError(err).WithField("job", execDoneReq.Execution.JobName).Error("grpc: Error retrieving job from store")
 		return nil, err
 	}
 
@@ -207,7 +209,7 @@ func (grpcs *GRPCServer) ExecutionDone(ctx context.Context, execDoneReq *proto.E
 		// Keep all execution properties intact except the last output
 		execution.Output = ""
 
-		log.WithFields(logrus.Fields{
+		grpcs.logger.WithFields(logrus.Fields{
 			"attempt":   execution.Attempt,
 			"execution": execution,
 		}).Debug("grpc: Retrying execution")
@@ -221,18 +223,18 @@ func (grpcs *GRPCServer) ExecutionDone(ctx context.Context, execDoneReq *proto.E
 		}, nil
 	}
 
-	exg, err := grpcs.agent.Store.GetExecutionGroup(execution, 
+	exg, err := grpcs.agent.Store.GetExecutionGroup(execution,
 		&ExecutionOptions{
 			Timezone: job.GetTimeLocation(),
 		},
 	)
 	if err != nil {
-		log.WithError(err).WithField("group", execution.Group).Error("grpc: Error getting execution group.")
+		grpcs.logger.WithError(err).WithField("group", execution.Group).Error("grpc: Error getting execution group.")
 		return nil, err
 	}
 
 	// Send notification
-	if err := Notification(grpcs.agent.config, execution, exg, job).Send(); err != nil {
+	if err := Notification(grpcs.agent.config, execution, exg, job).Send(grpcs.logger); err != nil {
 		return nil, err
 	}
 
@@ -245,7 +247,7 @@ func (grpcs *GRPCServer) ExecutionDone(ctx context.Context, execDoneReq *proto.E
 			if err != nil {
 				return nil, err
 			}
-			log.WithField("job", djn).Debug("grpc: Running dependent job")
+			grpcs.logger.WithField("job", djn).Debug("grpc: Running dependent job")
 			dj.Run()
 		}
 	}
@@ -358,11 +360,11 @@ REMOVE:
 	// pass.
 	future := grpcs.agent.raft.RemoveServer(raft.ServerID(in.Id), 0, 0)
 	if err := future.Error(); err != nil {
-		log.WithError(err).WithField("peer", in.Id).Warn("failed to remove Raft peer")
+		grpcs.logger.WithError(err).WithField("peer", in.Id).Warn("failed to remove Raft peer")
 		return nil, err
 	}
 
-	log.WithField("peer", in.Id).Warn("removed Raft peer")
+	grpcs.logger.WithField("peer", in.Id).Warn("removed Raft peer")
 	return new(empty.Empty), nil
 }
 
@@ -386,18 +388,18 @@ func (grpcs *GRPCServer) GetActiveExecutions(ctx context.Context, in *empty.Empt
 // This only works on the leader
 func (grpcs *GRPCServer) SetExecution(ctx context.Context, execution *proto.Execution) (*empty.Empty, error) {
 	defer metrics.MeasureSince([]string{"grpc", "set_execution"}, time.Now())
-	log.WithFields(logrus.Fields{
+	grpcs.logger.WithFields(logrus.Fields{
 		"execution": execution.Key(),
 	}).Debug("grpc: Received SetExecution")
 
 	cmd, err := Encode(SetExecutionType, execution)
 	if err != nil {
-		log.WithError(err).Fatal("agent: encode error in SetExecution")
+		grpcs.logger.WithError(err).Fatal("agent: encode error in SetExecution")
 		return nil, err
 	}
 	af := grpcs.agent.raft.Apply(cmd, raftTimeout)
 	if err := af.Error(); err != nil {
-		log.WithError(err).Fatal("agent: error applying SetExecutionType")
+		grpcs.logger.WithError(err).Fatal("agent: error applying SetExecutionType")
 		return nil, err
 	}
 

--- a/dkron/grpc_agent.go
+++ b/dkron/grpc_agent.go
@@ -35,13 +35,15 @@ func (s *statusAgentHelper) Update(b []byte, c bool) (int64, error) {
 // GRPCAgentServer is the local implementation of the gRPC server interface.
 type AgentServer struct {
 	types.AgentServer
-	agent *Agent
+	agent  *Agent
+	logger *logrus.Entry
 }
 
 // NewServer creates and returns an instance of a DkronGRPCServer implementation
-func NewAgentServer(agent *Agent) types.AgentServer {
+func NewAgentServer(agent *Agent, logger *logrus.Entry) types.AgentServer {
 	return &AgentServer{
-		agent: agent,
+		agent:  agent,
+		logger: logger,
 	}
 }
 
@@ -53,7 +55,7 @@ func (as *AgentServer) AgentRun(req *types.AgentRunRequest, stream types.Agent_A
 	job := req.Job
 	execution := req.Execution
 
-	log.WithFields(logrus.Fields{
+	as.logger.WithFields(logrus.Fields{
 		"job": job.Name,
 	}).Info("grpc_agent: Starting job")
 
@@ -80,7 +82,7 @@ func (as *AgentServer) AgentRun(req *types.AgentRunRequest, stream types.Agent_A
 
 	// Check if executor exists
 	if executor, ok := as.agent.ExecutorPlugins[jex]; ok {
-		log.WithField("plugin", jex).Debug("grpc_agent: calling executor plugin")
+		as.logger.WithField("plugin", jex).Debug("grpc_agent: calling executor plugin")
 		runningExecutions.Store(execution.GetGroup(), execution)
 		out, err := executor.Execute(&types.ExecuteRequest{
 			JobName: job.Name,
@@ -94,7 +96,7 @@ func (as *AgentServer) AgentRun(req *types.AgentRunRequest, stream types.Agent_A
 			err = errors.New(out.Error)
 		}
 		if err != nil {
-			log.WithError(err).WithField("job", job.Name).WithField("plugin", executor).Error("grpc_agent: command error output")
+			as.logger.WithError(err).WithField("job", job.Name).WithField("plugin", executor).Error("grpc_agent: command error output")
 			success = false
 			output.Write([]byte(err.Error() + "\n"))
 		} else {
@@ -105,7 +107,7 @@ func (as *AgentServer) AgentRun(req *types.AgentRunRequest, stream types.Agent_A
 			output.Write(out.Output)
 		}
 	} else {
-		log.WithField("executor", jex).Error("grpc_agent: Specified executor is not present")
+		as.logger.WithField("executor", jex).Error("grpc_agent: Specified executor is not present")
 		output.Write([]byte("grpc_agent: Specified executor is not present"))
 	}
 
@@ -120,7 +122,7 @@ func (as *AgentServer) AgentRun(req *types.AgentRunRequest, stream types.Agent_A
 		Execution: execution,
 	}); err != nil {
 		// In case of error means that maybe the server is gone so fallback to ExecutionDone
-		log.WithError(err).WithField("job", job.Name).Error("grpc_agent: error sending the final execution, falling back to ExecutionDone")
+		as.logger.WithError(err).WithField("job", job.Name).Error("grpc_agent: error sending the final execution, falling back to ExecutionDone")
 		rpcServer, err := as.agent.checkAndSelectServer()
 		if err != nil {
 			return err

--- a/dkron/grpc_client.go
+++ b/dkron/grpc_client.go
@@ -35,10 +35,11 @@ type DkronGRPCClient interface {
 type GRPCClient struct {
 	dialOpt []grpc.DialOption
 	agent   *Agent
+	logger  *logrus.Entry
 }
 
 // NewGRPCClient returns a new instance of the gRPC client.
-func NewGRPCClient(dialOpt grpc.DialOption, agent *Agent) DkronGRPCClient {
+func NewGRPCClient(dialOpt grpc.DialOption, agent *Agent, logger *logrus.Entry) DkronGRPCClient {
 	if dialOpt == nil {
 		dialOpt = grpc.WithInsecure()
 	}
@@ -47,7 +48,8 @@ func NewGRPCClient(dialOpt grpc.DialOption, agent *Agent) DkronGRPCClient {
 			dialOpt,
 			grpc.WithBlock(),
 		},
-		agent: agent,
+		agent:  agent,
+		logger: logger,
 	}
 }
 
@@ -70,7 +72,7 @@ func (grpcc *GRPCClient) ExecutionDone(addr string, execution *Execution) error 
 
 	conn, err := grpcc.Connect(addr)
 	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
+		grpcc.logger.WithError(err).WithFields(logrus.Fields{
 			"method":      "ExecutionDone",
 			"server_addr": addr,
 		}).Error("grpc: error dialing.")
@@ -81,18 +83,18 @@ func (grpcc *GRPCClient) ExecutionDone(addr string, execution *Execution) error 
 	edr, err := d.ExecutionDone(context.Background(), &proto.ExecutionDoneRequest{Execution: execution.ToProto()})
 	if err != nil {
 		if err.Error() == fmt.Sprintf("rpc error: code = Unknown desc = %s", ErrNotLeader.Error()) {
-			log.Info("grpc: ExecutionDone forwarded to the leader")
+			grpcc.logger.Info("grpc: ExecutionDone forwarded to the leader")
 			conn.Close()
 			return nil
 		}
 
-		log.WithError(err).WithFields(logrus.Fields{
+		grpcc.logger.WithError(err).WithFields(logrus.Fields{
 			"method":      "ExecutionDone",
 			"server_addr": addr,
 		}).Error("grpc: Error calling gRPC method")
 		return err
 	}
-	log.WithFields(logrus.Fields{
+	grpcc.logger.WithFields(logrus.Fields{
 		"method":      "ExecutionDone",
 		"server_addr": addr,
 		"from":        edr.From,
@@ -110,7 +112,7 @@ func (grpcc *GRPCClient) GetJob(addr, jobName string) (*Job, error) {
 	// Initiate a connection with the server
 	conn, err := grpcc.Connect(addr)
 	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
+		grpcc.logger.WithError(err).WithFields(logrus.Fields{
 			"method":      "GetJob",
 			"server_addr": addr,
 		}).Error("grpc: error dialing.")
@@ -122,7 +124,7 @@ func (grpcc *GRPCClient) GetJob(addr, jobName string) (*Job, error) {
 	d := proto.NewDkronClient(conn)
 	gjr, err := d.GetJob(context.Background(), &proto.GetJobRequest{JobName: jobName})
 	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
+		grpcc.logger.WithError(err).WithFields(logrus.Fields{
 			"method":      "GetJob",
 			"server_addr": addr,
 		}).Error("grpc: Error calling gRPC method")
@@ -139,7 +141,7 @@ func (grpcc *GRPCClient) Leave(addr string) error {
 	// Initiate a connection with the server
 	conn, err := grpcc.Connect(addr)
 	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
+		grpcc.logger.WithError(err).WithFields(logrus.Fields{
 			"method":      "Leave",
 			"server_addr": addr,
 		}).Error("grpc: error dialing.")
@@ -151,7 +153,7 @@ func (grpcc *GRPCClient) Leave(addr string) error {
 	d := proto.NewDkronClient(conn)
 	_, err = d.Leave(context.Background(), &empty.Empty{})
 	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
+		grpcc.logger.WithError(err).WithFields(logrus.Fields{
 			"method":      "Leave",
 			"server_addr": addr,
 		}).Error("grpc: Error calling gRPC method")
@@ -170,7 +172,7 @@ func (grpcc *GRPCClient) SetJob(job *Job) error {
 	// Initiate a connection with the server
 	conn, err := grpcc.Connect(string(addr))
 	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
+		grpcc.logger.WithError(err).WithFields(logrus.Fields{
 			"method":      "SetJob",
 			"server_addr": addr,
 		}).Error("grpc: error dialing.")
@@ -184,7 +186,7 @@ func (grpcc *GRPCClient) SetJob(job *Job) error {
 		Job: job.ToProto(),
 	})
 	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
+		grpcc.logger.WithError(err).WithFields(logrus.Fields{
 			"method":      "SetJob",
 			"server_addr": addr,
 		}).Error("grpc: Error calling gRPC method")
@@ -202,7 +204,7 @@ func (grpcc *GRPCClient) DeleteJob(jobName string) (*Job, error) {
 	// Initiate a connection with the server
 	conn, err := grpcc.Connect(string(addr))
 	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
+		grpcc.logger.WithError(err).WithFields(logrus.Fields{
 			"method":      "DeleteJob",
 			"server_addr": addr,
 		}).Error("grpc: error dialing.")
@@ -216,7 +218,7 @@ func (grpcc *GRPCClient) DeleteJob(jobName string) (*Job, error) {
 		JobName: jobName,
 	})
 	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
+		grpcc.logger.WithError(err).WithFields(logrus.Fields{
 			"method":      "DeleteJob",
 			"server_addr": addr,
 		}).Error("grpc: Error calling gRPC method")
@@ -237,7 +239,7 @@ func (grpcc *GRPCClient) RunJob(jobName string) (*Job, error) {
 	// Initiate a connection with the server
 	conn, err := grpcc.Connect(string(addr))
 	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
+		grpcc.logger.WithError(err).WithFields(logrus.Fields{
 			"method":      "RunJob",
 			"server_addr": addr,
 		}).Error("grpc: error dialing.")
@@ -251,7 +253,7 @@ func (grpcc *GRPCClient) RunJob(jobName string) (*Job, error) {
 		JobName: jobName,
 	})
 	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
+		grpcc.logger.WithError(err).WithFields(logrus.Fields{
 			"method":      "RunJob",
 			"server_addr": addr,
 		}).Error("grpc: Error calling gRPC method")
@@ -270,7 +272,7 @@ func (grpcc *GRPCClient) RaftGetConfiguration(addr string) (*proto.RaftGetConfig
 	// Initiate a connection with the server
 	conn, err := grpcc.Connect(addr)
 	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
+		grpcc.logger.WithError(err).WithFields(logrus.Fields{
 			"method":      "RaftGetConfiguration",
 			"server_addr": addr,
 		}).Error("grpc: error dialing.")
@@ -282,7 +284,7 @@ func (grpcc *GRPCClient) RaftGetConfiguration(addr string) (*proto.RaftGetConfig
 	d := proto.NewDkronClient(conn)
 	res, err := d.RaftGetConfiguration(context.Background(), &empty.Empty{})
 	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
+		grpcc.logger.WithError(err).WithFields(logrus.Fields{
 			"method":      "RaftGetConfiguration",
 			"server_addr": addr,
 		}).Error("grpc: Error calling gRPC method")
@@ -299,7 +301,7 @@ func (grpcc *GRPCClient) RaftRemovePeerByID(addr, peerID string) error {
 	// Initiate a connection with the server
 	conn, err := grpcc.Connect(addr)
 	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
+		grpcc.logger.WithError(err).WithFields(logrus.Fields{
 			"method":      "RaftRemovePeerByID",
 			"server_addr": addr,
 		}).Error("grpc: error dialing.")
@@ -313,7 +315,7 @@ func (grpcc *GRPCClient) RaftRemovePeerByID(addr, peerID string) error {
 		&proto.RaftRemovePeerByIDRequest{Id: peerID},
 	)
 	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
+		grpcc.logger.WithError(err).WithFields(logrus.Fields{
 			"method":      "RaftRemovePeerByID",
 			"server_addr": addr,
 		}).Error("grpc: Error calling gRPC method")
@@ -330,7 +332,7 @@ func (grpcc *GRPCClient) GetActiveExecutions(addr string) ([]*proto.Execution, e
 	// Initiate a connection with the server
 	conn, err := grpcc.Connect(addr)
 	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
+		grpcc.logger.WithError(err).WithFields(logrus.Fields{
 			"method":      "GetActiveExecutions",
 			"server_addr": addr,
 		}).Error("grpc: error dialing.")
@@ -342,7 +344,7 @@ func (grpcc *GRPCClient) GetActiveExecutions(addr string) ([]*proto.Execution, e
 	d := proto.NewDkronClient(conn)
 	gaer, err := d.GetActiveExecutions(context.Background(), &empty.Empty{})
 	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
+		grpcc.logger.WithError(err).WithFields(logrus.Fields{
 			"method":      "GetActiveExecutions",
 			"server_addr": addr,
 		}).Error("grpc: Error calling gRPC method")
@@ -361,7 +363,7 @@ func (grpcc *GRPCClient) SetExecution(execution *proto.Execution) error {
 	// Initiate a connection with the server
 	conn, err := grpcc.Connect(string(addr))
 	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
+		grpcc.logger.WithError(err).WithFields(logrus.Fields{
 			"method":      "SetExecution",
 			"server_addr": addr,
 		}).Error("grpc: error dialing.")
@@ -373,7 +375,7 @@ func (grpcc *GRPCClient) SetExecution(execution *proto.Execution) error {
 	d := proto.NewDkronClient(conn)
 	_, err = d.SetExecution(context.Background(), execution)
 	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
+		grpcc.logger.WithError(err).WithFields(logrus.Fields{
 			"method":      "SetExecution",
 			"server_addr": addr,
 		}).Error("grpc: Error calling gRPC method")
@@ -390,7 +392,7 @@ func (grpcc *GRPCClient) AgentRun(addr string, job *proto.Job, execution *proto.
 	// Initiate a connection with the server
 	conn, err := grpcc.Connect(string(addr))
 	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
+		grpcc.logger.WithError(err).WithFields(logrus.Fields{
 			"method":      "AgentRun",
 			"server_addr": addr,
 		}).Error("grpc: error dialing.")
@@ -427,7 +429,7 @@ func (grpcc *GRPCClient) AgentRun(addr string, job *proto.Job, execution *proto.
 			execution.FinishedAt = ptypes.TimestampNow()
 			execution.Output = []byte(err.Error())
 
-			log.WithError(err).Error(ErrBrokenStream)
+			grpcc.logger.WithError(err).Error(ErrBrokenStream)
 
 			addr := grpcc.agent.raft.Leader()
 			if err := grpcc.ExecutionDone(string(addr), NewExecutionFromProto(execution)); err != nil {
@@ -438,7 +440,7 @@ func (grpcc *GRPCClient) AgentRun(addr string, job *proto.Job, execution *proto.
 
 		// Registers an active stream
 		grpcc.agent.activeExecutions.Store(ars.Execution.Key(), ars.Execution)
-		log.WithField("key", ars.Execution.Key()).Debug("grpc: received execution stream")
+		grpcc.logger.WithField("key", ars.Execution.Key()).Debug("grpc: received execution stream")
 
 		execution = ars.Execution
 		defer grpcc.agent.activeExecutions.Delete(execution.Key())

--- a/dkron/grpc_test.go
+++ b/dkron/grpc_test.go
@@ -74,7 +74,8 @@ func TestGRPCExecutionDone(t *testing.T) {
 		Output:     "test",
 	}
 
-	rc := NewGRPCClient(nil, a)
+	log := getTestLogger()
+	rc := NewGRPCClient(nil, a, log)
 	rc.ExecutionDone(a.advertiseRPCAddr(), testExecution)
 	execs, err := a.Store.GetExecutions("test", &ExecutionOptions{})
 	require.NoError(t, err)

--- a/dkron/job_test.go
+++ b/dkron/job_test.go
@@ -8,13 +8,22 @@ import (
 	"github.com/distribworks/dkron/v3/plugin"
 	proto "github.com/distribworks/dkron/v3/plugin/types"
 	"github.com/hashicorp/serf/testutil"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
 
+func getTestLogger() *logrus.Entry {
+	log := logrus.New()
+	log.Level = logrus.DebugLevel
+	entry := logrus.NewEntry(log)
+	return entry
+}
+
 func TestJobGetParent(t *testing.T) {
-	s, err := NewStore()
+	log := getTestLogger()
+	s, err := NewStore(log)
 	defer s.Shutdown()
 	require.NoError(t, err)
 
@@ -152,9 +161,11 @@ func Test_isRunnable(t *testing.T) {
 		},
 	}
 
+	log := getTestLogger()
+
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.job.isRunnable())
+			assert.Equal(t, tt.want, tt.job.isRunnable(log))
 		})
 	}
 }
@@ -175,7 +186,7 @@ func (gRPCClientMock) RaftGetConfiguration(s string) (*proto.RaftGetConfiguratio
 func (gRPCClientMock) RaftRemovePeerByID(s string, a string) error { return nil }
 func (gRPCClientMock) GetActiveExecutions(s string) ([]*proto.Execution, error) {
 	return []*proto.Execution{
-		&proto.Execution{
+		{
 			JobName: "test_job",
 		},
 	}, nil

--- a/dkron/log.go
+++ b/dkron/log.go
@@ -7,10 +7,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var log = logrus.NewEntry(logrus.New())
-
 // InitLogger creates the logger instance
-func InitLogger(logLevel string, node string) logrus.FieldLogger {
+func InitLogger(logLevel string, node string) *logrus.Entry {
 	formattedLogger := logrus.New()
 	formattedLogger.Formatter = &logrus.TextFormatter{FullTimestamp: true}
 
@@ -21,7 +19,7 @@ func InitLogger(logLevel string, node string) logrus.FieldLogger {
 	}
 
 	formattedLogger.Level = level
-	log = logrus.NewEntry(formattedLogger).WithField("node", node)
+	log := logrus.NewEntry(formattedLogger).WithField("node", node)
 
 	if level == logrus.DebugLevel {
 		gin.DefaultWriter = log.Writer()

--- a/dkron/notifier_test.go
+++ b/dkron/notifier_test.go
@@ -24,8 +24,8 @@ func TestNotifier_callExecutionWebhook(t *testing.T) {
 	}
 
 	n := Notification(c, &Execution{}, []*Execution{}, &Job{})
-
-	assert.NoError(t, n.Send())
+	log := getTestLogger()
+	assert.NoError(t, n.Send(log))
 }
 
 func TestNotifier_sendExecutionEmail(t *testing.T) {
@@ -61,8 +61,9 @@ func TestNotifier_sendExecutionEmail(t *testing.T) {
 		ex1,
 	}
 
+	log := getTestLogger()
 	n := Notification(c, ex1, exg, job)
-	assert.NoError(t, n.Send())
+	assert.NoError(t, n.Send(log))
 }
 
 func Test_auth(t *testing.T) {
@@ -111,9 +112,10 @@ func TestNotifier_buildTemplate(t *testing.T) {
 		ex1,
 	}
 
+	log := getTestLogger()
 	n := Notification(c, ex1, exg, nil)
 	for _, tc := range templateTestCases(n) {
-		got := n.buildTemplate(tc.template).String()
+		got := n.buildTemplate(tc.template, log).String()
 
 		if tc.exp != got {
 			t.Errorf("Exp: %s\nGot: %s", tc.exp, got)

--- a/dkron/raft_grpc.go
+++ b/dkron/raft_grpc.go
@@ -7,18 +7,20 @@ import (
 	"time"
 
 	"github.com/hashicorp/raft"
+	"github.com/sirupsen/logrus"
 )
 
 // RaftLayer is the network layer for internode communications.
 type RaftLayer struct {
 	TLSConfig *tls.Config
 
-	ln net.Listener
+	ln     net.Listener
+	logger *logrus.Entry
 }
 
 // NewRaftLayer returns an initialized unecrypted RaftLayer.
-func NewRaftLayer() *RaftLayer {
-	return &RaftLayer{}
+func NewRaftLayer(logger *logrus.Entry) *RaftLayer {
+	return &RaftLayer{logger: logger}
 }
 
 // NewTLSRaftLayer returns an initialized TLS-ecrypted RaftLayer.
@@ -39,7 +41,7 @@ func (t *RaftLayer) Dial(addr raft.ServerAddress, timeout time.Duration) (net.Co
 	var err error
 	var conn net.Conn
 	if t.TLSConfig != nil {
-		log.Debug("doing a TLS dial")
+		t.logger.Debug("doing a TLS dial")
 		conn, err = tls.DialWithDialer(dialer, "tcp", string(addr), t.TLSConfig)
 	} else {
 		conn, err = dialer.Dial("tcp", string(addr))

--- a/dkron/scheduler_test.go
+++ b/dkron/scheduler_test.go
@@ -8,7 +8,8 @@ import (
 )
 
 func TestSchedule(t *testing.T) {
-	sched := NewScheduler()
+	log := getTestLogger()
+	sched := NewScheduler(log)
 
 	assert.False(t, sched.Started)
 
@@ -48,7 +49,8 @@ func TestSchedule(t *testing.T) {
 }
 
 func TestTimezoneAwareJob(t *testing.T) {
-	sched := NewScheduler()
+	log := getTestLogger()
+	sched := NewScheduler(log)
 
 	tzJob := &Job{
 		Name:           "cron_job",

--- a/dkron/store.go
+++ b/dkron/store.go
@@ -37,6 +37,8 @@ var (
 type Store struct {
 	db   *buntdb.DB
 	lock *sync.Mutex // for
+
+	logger *logrus.Entry
 }
 
 // JobOptions additional options to apply when loading a Job.
@@ -62,7 +64,7 @@ type kv struct {
 }
 
 // NewStore creates a new Storage instance.
-func NewStore() (*Store, error) {
+func NewStore(logger *logrus.Entry) (*Store, error) {
 	db, err := buntdb.Open(":memory:")
 	db.CreateIndex("name", jobsPrefix+":*", buntdb.IndexJSON("name"))
 	db.CreateIndex("started_at", executionsPrefix+":*", buntdb.IndexJSON("started_at"))
@@ -80,8 +82,9 @@ func NewStore() (*Store, error) {
 	}
 
 	store := &Store{
-		db:   db,
-		lock: &sync.Mutex{},
+		db:     db,
+		lock:   &sync.Mutex{},
+		logger: logger,
 	}
 
 	return store, nil
@@ -95,7 +98,7 @@ func (s *Store) setJobTxFunc(pbj *dkronpb.Job) func(tx *buntdb.Tx) error {
 		if err != nil {
 			return err
 		}
-		log.WithField("job", pbj.Name).Debug("store: Setting job")
+		s.logger.WithField("job", pbj.Name).Debug("store: Setting job")
 
 		if _, _, err := tx.Set(jobKey, string(jb), nil); err != nil {
 			return err
@@ -248,10 +251,10 @@ func (s *Store) SetExecutionDone(execution *Execution) (bool, error) {
 		var pbj dkronpb.Job
 		if err := s.getJobTxFunc(execution.JobName, &pbj)(tx); err != nil {
 			if err == buntdb.ErrNotFound {
-				log.Warning(ErrExecutionDoneForDeletedJob)
+				s.logger.Warn(ErrExecutionDoneForDeletedJob)
 				return ErrExecutionDoneForDeletedJob
 			}
-			log.WithError(err).Fatal(err)
+			s.logger.WithError(err).Fatal(err)
 			return err
 		}
 
@@ -286,7 +289,7 @@ func (s *Store) SetExecutionDone(execution *Execution) (bool, error) {
 		return nil
 	})
 	if err != nil {
-		log.WithError(err).Error("store: Error in SetExecutionDone")
+		s.logger.WithError(err).Error("store: Error in SetExecutionDone")
 		return false, err
 	}
 
@@ -326,12 +329,13 @@ func (s *Store) GetJobs(options *JobOptions) ([]*Job, error) {
 			}
 		}
 		job := NewJobFromProto(&pbj)
+		job.logger = s.logger
 
 		if options == nil ||
 			(options.Metadata == nil || len(options.Metadata) == 0 || s.jobHasMetadata(job, options.Metadata)) &&
-			(options.Query == "" || strings.Contains(job.Name, options.Query) || strings.Contains(job.DisplayName, options.Query)) &&
-			(options.Disabled == "" || strconv.FormatBool(job.Disabled) == options.Disabled) && 
-			((options.Status == "untriggered" && job.Status == "") || (options.Status == "" || job.Status == options.Status)) {
+				(options.Query == "" || strings.Contains(job.Name, options.Query) || strings.Contains(job.DisplayName, options.Query)) &&
+				(options.Disabled == "" || strconv.FormatBool(job.Disabled) == options.Disabled) &&
+				((options.Status == "untriggered" && job.Status == "") || (options.Status == "" || job.Status == options.Status)) {
 
 			jobs = append(jobs, job)
 		}
@@ -361,6 +365,7 @@ func (s *Store) GetJob(name string, options *JobOptions) (*Job, error) {
 	}
 
 	job := NewJobFromProto(&pbj)
+	job.logger = s.logger
 
 	return job, nil
 }
@@ -381,7 +386,7 @@ func (s *Store) getJobTxFunc(name string, pbj *dkronpb.Job) func(tx *buntdb.Tx) 
 			}
 		}
 
-		log.WithFields(logrus.Fields{
+		s.logger.WithFields(logrus.Fields{
 			"job": pbj.Name,
 		}).Debug("store: Retrieved job from datastore")
 
@@ -552,7 +557,7 @@ func (s *Store) SetExecution(execution *Execution) (string, error) {
 	pbe := execution.ToProto()
 	key := fmt.Sprintf("%s:%s:%s", executionsPrefix, execution.JobName, execution.Key())
 
-	log.WithFields(logrus.Fields{
+	s.logger.WithFields(logrus.Fields{
 		"job":       execution.JobName,
 		"execution": key,
 		"finished":  execution.FinishedAt.String(),
@@ -561,7 +566,7 @@ func (s *Store) SetExecution(execution *Execution) (string, error) {
 	err := s.db.Update(s.setExecutionTxFunc(key, pbe))
 
 	if err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
+		s.logger.WithError(err).WithFields(logrus.Fields{
 			"job":       execution.JobName,
 			"execution": key,
 		}).Debug("store: Failed to set key")
@@ -570,7 +575,7 @@ func (s *Store) SetExecution(execution *Execution) (string, error) {
 
 	execs, err := s.GetExecutions(execution.JobName, &ExecutionOptions{})
 	if err != nil && err != buntdb.ErrNotFound {
-		log.WithError(err).
+		s.logger.WithError(err).
 			WithField("job", execution.JobName).
 			Error("store: Error getting executions for job")
 	}
@@ -583,7 +588,7 @@ func (s *Store) SetExecution(execution *Execution) (string, error) {
 		})
 
 		for i := 0; i < len(execs)-MaxExecutions; i++ {
-			log.WithFields(logrus.Fields{
+			s.logger.WithFields(logrus.Fields{
 				"job":       execs[i].JobName,
 				"execution": execs[i].Key(),
 			}).Debug("store: to detele key")
@@ -593,7 +598,7 @@ func (s *Store) SetExecution(execution *Execution) (string, error) {
 				return err
 			})
 			if err != nil {
-				log.WithError(err).
+				s.logger.WithError(err).
 					WithField("execution", execs[i].Key()).
 					Error("store: Error trying to delete overflowed execution")
 			}
@@ -647,7 +652,7 @@ func (s *Store) unmarshalExecutions(items []kv, timezone *time.Location) ([]*Exe
 		// so we can use BuntDb indexes. To be removed in future versions.
 		if err := proto.Unmarshal([]byte(item.Value), &pbe); err != nil {
 			if err := json.Unmarshal(item.Value, &pbe); err != nil {
-				log.WithError(err).WithField("key", item.Key).Debug("error unmarshaling JSON")
+				s.logger.WithError(err).WithField("key", item.Key).Debug("error unmarshaling JSON")
 				return nil, err
 			}
 		}

--- a/dkron/store_test.go
+++ b/dkron/store_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 func TestStore(t *testing.T) {
-	s, err := NewStore()
+	log := getTestLogger()
+	s, err := NewStore(log)
 	require.NoError(t, err)
 	defer s.Shutdown()
 
@@ -70,7 +71,7 @@ func TestStore(t *testing.T) {
 	require.NoError(t, err)
 
 	execs, err := s.GetExecutions("test", &ExecutionOptions{
-		Sort: "started_at",
+		Sort:  "started_at",
 		Order: "DESC",
 	})
 	assert.NoError(t, err)
@@ -201,7 +202,8 @@ func TestStore_GetJobsWithMetadata(t *testing.T) {
 }
 
 func Test_computeStatus(t *testing.T) {
-	s, err := NewStore()
+	log := getTestLogger()
+	s, err := NewStore(log)
 	require.NoError(t, err)
 
 	n := time.Now()
@@ -322,7 +324,8 @@ func scaffoldJob() *Job {
 }
 
 func setupStore(t *testing.T) *Store {
-	s, err := NewStore()
+	log := getTestLogger()
+	s, err := NewStore(log)
 	require.NoError(t, err)
 	return s
 }

--- a/dkron/ui.go
+++ b/dkron/ui.go
@@ -33,19 +33,19 @@ func (h *HTTPTransport) UI(r *gin.RouterGroup) {
 
 	assets, err := fs.Sub(uiDist, "ui-dist")
 	if err != nil {
-		log.Fatal(err)
+		h.logger.Fatal(err)
 	}
 	a, err := assets.Open("index.html")
 	if err != nil {
-		log.Fatal(err)
+		h.logger.Fatal(err)
 	}
 	b, err := ioutil.ReadAll(a)
 	if err != nil {
-		log.Fatal(err)
+		h.logger.Fatal(err)
 	}
 	t, err := template.New("index.html").Parse(string(b))
 	if err != nil {
-		log.Fatal(err)
+		h.logger.Fatal(err)
 	}
 	h.Engine.SetHTMLTemplate(t)
 
@@ -58,7 +58,7 @@ func (h *HTTPTransport) UI(r *gin.RouterGroup) {
 		} else {
 			jobs, err := h.agent.Store.GetJobs(nil)
 			if err != nil {
-				log.Error(err)
+				h.logger.Error(err)
 			}
 			var (
 				totalJobs                                   = len(jobs)
@@ -76,7 +76,7 @@ func (h *HTTPTransport) UI(r *gin.RouterGroup) {
 			l, err := h.agent.leaderMember()
 			ln := "no leader"
 			if err != nil {
-				log.Error(err)
+				h.logger.Error(err)
 			} else {
 				ln = l.Name
 			}


### PR DESCRIPTION
This converts all logging calls to a logrus instance that is passed into types or functions instead of a package level variable. This is to help prevent any possible race conditions with the variable and it also helps show the dependency on logging for each type instead of an implicit reference.

Originally I attempted to abstract a logging interface away from logrus but so much of the logrus API is being used that it was quite difficult to abstract away and there was not much direct benefit from doing so. The tests are all passing and I did test running docker-compose locally. I can add jobs via the UI and execute them with no panics. I feel relatively confident with these changes, but I'm not sure how complete the test coverage is in order to prove that.

I'm open to feedback here if there are improvements that can be made. The Job logging calls felt the most difficult because the Run method is not allowed to have parameters so I had to have the scheduler set the logger on the jobs before returning them. 

This helps improve #951 