### PR TITLE
Fix race conditions

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -244,7 +244,7 @@ func (a *Agent) Stop() error {
 		a.Store.Shutdown()
 	}
 
-	if a.config.Server && a.sched.Started {
+	if a.config.Server && a.sched.Started() {
 		a.sched.Stop()
 		a.sched.ClearCron()
 	}

--- a/dkron/scheduler_test.go
+++ b/dkron/scheduler_test.go
@@ -11,7 +11,8 @@ func TestSchedule(t *testing.T) {
 	log := getTestLogger()
 	sched := NewScheduler(log)
 
-	assert.False(t, sched.Started)
+	assert.False(t, sched.started)
+	assert.False(t, sched.Started())
 
 	testJob1 := &Job{
 		Name:           "cron_job",
@@ -23,7 +24,8 @@ func TestSchedule(t *testing.T) {
 	}
 	sched.Start([]*Job{testJob1}, &Agent{})
 
-	assert.True(t, sched.Started)
+	assert.True(t, sched.started)
+	assert.True(t, sched.Started())
 	now := time.Now().Truncate(time.Second)
 
 	entry, _ := sched.GetEntry(testJob1.Name)
@@ -39,7 +41,8 @@ func TestSchedule(t *testing.T) {
 	}
 	sched.Restart([]*Job{testJob2}, &Agent{})
 
-	assert.True(t, sched.Started)
+	assert.True(t, sched.started)
+	assert.True(t, sched.Started())
 	assert.Len(t, sched.Cron.Entries(), 1)
 
 	sched.Cron.Remove(1)
@@ -61,7 +64,8 @@ func TestTimezoneAwareJob(t *testing.T) {
 	}
 	sched.Start([]*Job{tzJob}, &Agent{})
 
-	assert.True(t, sched.Started)
+	assert.True(t, sched.started)
+	assert.True(t, sched.Started())
 	assert.Len(t, sched.Cron.Entries(), 1)
 	sched.Stop()
 }


### PR DESCRIPTION
- Add workaround for package level variables in gin framework
- Add mutext around Scheduler.started to prevent concurrent modifications
- Scheduler.Started renamed to .started as a private property, Ability to query on started status now through Started()

These changes allow the tests to be run with the -race flag and not return any warnings about race conditions.

Fixes #951 