### PR TITLE
Refactor processFilteredNodes for testing

### DIFF
--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -745,14 +745,14 @@ func (a *Agent) processFilteredNodes(job *Job) (map[string]string, map[string]st
 	return nodes, tags, nil
 }
 
-// filterNodes determines which of the execNodes have the given tags
+// filterNodes determines which of the provided nodes have the given tags
 // Returns:
-// * the map of execNodes that match the provided tags
+// * the map of allNodes that match the provided tags
 // * a clean map of tag values without cardinality
 // * cardinality, i.e. the max number of nodes that should be targeted, regardless of the
 //   number of nodes in the resulting map.
 // * an error if a cardinality was malformed
-func filterNodes(execNodes map[string]serf.Member, tags map[string]string) (map[string]serf.Member, map[string]string, int, error) {
+func filterNodes(allNodes map[string]serf.Member, tags map[string]string) (map[string]serf.Member, map[string]string, int, error) {
 	ct, cardinality, err := cleanTags(tags)
 	if err != nil {
 		return nil, nil, 0, err
@@ -761,7 +761,7 @@ func filterNodes(execNodes map[string]serf.Member, tags map[string]string) (map[
 	matchingNodes := make(map[string]serf.Member)
 
 	// Filter nodes that lack tags
-	for name, member := range execNodes {
+	for name, member := range allNodes {
 		if nodeMatchesTags(member, ct) {
 			matchingNodes[name] = member
 		}

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -762,8 +762,7 @@ func filterNodes(execNodes map[string]serf.Member, tags map[string]string) (map[
 
 	// Filter nodes that lack tags
 	for name, member := range execNodes {
-		nodeMatches := nodeMatchesTags(member, ct)
-		if nodeMatches {
+		if nodeMatchesTags(member, ct) {
 			matchingNodes[name] = member
 		}
 	}

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -150,6 +149,9 @@ func NewAgent(config *Config, options ...AgentOption) *Agent {
 func (a *Agent) Start() error {
 	log := InitLogger(a.config.LogLevel, a.config.NodeName)
 	a.logger = log
+
+	// Initialize rand with current time
+	rand.Seed(time.Now().UnixNano())
 
 	// Normalize configured addresses
 	a.config.normalizeAddrs()
@@ -704,14 +706,14 @@ func (a *Agent) processFilteredNodes(job *Job) (map[string]string, map[string]st
 	tags["region"] = a.config.Region
 
 	// Make a set of all members
-	execNodes := make(map[string]serf.Member)
+	allNodes := make(map[string]serf.Member)
 	for _, member := range a.serf.Members() {
 		if member.Status == serf.StatusAlive {
-			execNodes[member.Name] = member
+			allNodes[member.Name] = member
 		}
 	}
 
-	execNodes, tags, cardinality, err := filterNodes(execNodes, tags)
+	execNodes, tags, cardinality, err := filterNodes(allNodes, tags)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -723,7 +725,6 @@ func (a *Agent) processFilteredNodes(job *Job) (map[string]string, map[string]st
 	}
 
 	nodes := make(map[string]string)
-	rand.Seed(time.Now().UnixNano())
 	for ; cardinality > 0; cardinality-- {
 		// Pick a node, any node
 		randomIndex := rand.Intn(len(names))
@@ -745,51 +746,34 @@ func (a *Agent) processFilteredNodes(job *Job) (map[string]string, map[string]st
 }
 
 // filterNodes determines which of the execNodes have the given tags
-// Out param! The incoming execNodes map is modified.
 // Returns:
-// * the (modified) map of execNodes
-// * a map of tag values without cardinality
+// * the map of execNodes that match the provided tags
+// * a clean map of tag values without cardinality
 // * cardinality, i.e. the max number of nodes that should be targeted, regardless of the
 //   number of nodes in the resulting map.
 // * an error if a cardinality was malformed
 func filterNodes(execNodes map[string]serf.Member, tags map[string]string) (map[string]serf.Member, map[string]string, int, error) {
-	cardinality := int(^uint(0) >> 1) // MaxInt
+	ct, cardinality, err := cleanTags(tags)
+	if err != nil {
+		return nil, nil, 0, err
+	}
 
-	cleanTags := make(map[string]string)
+	matchingNodes := make(map[string]serf.Member)
 
 	// Filter nodes that lack tags
-	// Determine lowest cardinality along the way
-	for jtk, jtv := range tags {
-		tc := strings.Split(jtv, ":")
-		tv := tc[0]
-
-		// Set original tag to clean tag
-		cleanTags[jtk] = tv
-
-		// Remove nodes that do not have the selected tags
-		for name, member := range execNodes {
-			if mtv, tagPresent := member.Tags[jtk]; !tagPresent || mtv != tv {
-				delete(execNodes, name)
-			}
-		}
-
-		if len(tc) == 2 {
-			tagCardinality, err := strconv.Atoi(tc[1])
-			if err != nil {
-				return nil, nil, 0, err
-			}
-			if tagCardinality < cardinality {
-				cardinality = tagCardinality
-			}
+	for name, member := range execNodes {
+		nodeMatches := nodeMatchesTags(member, ct)
+		if nodeMatches {
+			matchingNodes[name] = member
 		}
 	}
 
 	// limit the cardinality to the number of possible nodes
-	if len(execNodes) < cardinality {
-		cardinality = len(execNodes)
+	if len(matchingNodes) < cardinality {
+		cardinality = len(matchingNodes)
 	}
 
-	return execNodes, cleanTags, cardinality, nil
+	return matchingNodes, ct, cardinality, nil
 }
 
 // This function is called when a client request the RPCAddress

--- a/dkron/tags.go
+++ b/dkron/tags.go
@@ -1,0 +1,54 @@
+package dkron
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/serf/serf"
+)
+
+// cleanTags takes the tag spec and returns strictly key:value pairs
+// along with the lowest cardinality specified
+func cleanTags(tags map[string]string) (map[string]string, int, error) {
+	cardinality := int(^uint(0) >> 1) // MaxInt
+
+	cleanTags := make(map[string]string, len(tags))
+
+	for k, v := range tags {
+		vparts := strings.Split(v, ":")
+
+		cleanTags[k] = vparts[0]
+
+		// If a cardinality is specified (i.e. "value:3") and it is lower than our
+		// max cardinality, lower the max
+		if len(vparts) == 2 {
+			tagCard, err := strconv.Atoi(vparts[1])
+			if err != nil {
+				// Tag value is malformed
+				return nil, 0, fmt.Errorf("imporper cardinality specified for tag %s: %v", k, vparts[1])
+			}
+
+			if tagCard < cardinality {
+				cardinality = tagCard
+			}
+		}
+	}
+
+	return cleanTags, cardinality, nil
+}
+
+// nodeMatchesTags encapsulates the logic of testing if a node matches all of the provided tags
+func nodeMatchesTags(node serf.Member, tags map[string]string) bool {
+	for k, v := range tags {
+		nodeVal, present := node.Tags[k]
+		if !present {
+			return false
+		}
+		if nodeVal != v {
+			return false
+		}
+	}
+	// If we matched all key:value pairs, the node matches the tags
+	return true
+}

--- a/dkron/tags.go
+++ b/dkron/tags.go
@@ -26,7 +26,7 @@ func cleanTags(tags map[string]string) (map[string]string, int, error) {
 			tagCard, err := strconv.Atoi(vparts[1])
 			if err != nil {
 				// Tag value is malformed
-				return nil, 0, fmt.Errorf("imporper cardinality specified for tag %s: %v", k, vparts[1])
+				return nil, 0, fmt.Errorf("improper cardinality specified for tag %s: %v", k, vparts[1])
 			}
 
 			if tagCard < cardinality {

--- a/dkron/tags_test.go
+++ b/dkron/tags_test.go
@@ -1,0 +1,66 @@
+package dkron
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_cleanTags(t *testing.T) {
+	maxInt := int(^uint(0) >> 1)
+	type args struct {
+		tags map[string]string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]string
+		want1   int
+		wantErr bool
+	}{
+		{
+			name:    "Clean Tags",
+			args:    args{map[string]string{"key1": "value1", "key2": "value2"}},
+			want:    map[string]string{"key1": "value1", "key2": "value2"},
+			want1:   maxInt,
+			wantErr: false,
+		},
+		{
+			name:    "With Cardinality",
+			args:    args{map[string]string{"key1": "value1", "key2": "value2:5"}},
+			want:    map[string]string{"key1": "value1", "key2": "value2"},
+			want1:   5,
+			wantErr: false,
+		},
+		{
+			name:    "With Multiple Cardinalities",
+			args:    args{map[string]string{"key1": "value1:2", "key2": "value2:5"}},
+			want:    map[string]string{"key1": "value1", "key2": "value2"},
+			want1:   2,
+			wantErr: false,
+		},
+		{
+			name:    "With String Cardinality",
+			args:    args{map[string]string{"key1": "value1", "key2": "value2:cardinality"}},
+			want:    nil,
+			want1:   0,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := cleanTags(tt.args.tags)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("cleanTags() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Logf("got map: %#v", got)
+				t.Logf("want map: %#v", tt.want)
+				t.Errorf("cleanTags() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("cleanTags() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I was digging into the intermittent failures of Test_processFilteredNodes and had trouble really understanding what the function, and the complimenting filterNodes were doing so I broke some of the logic out into smaller functions to encapsulate the logic and make testing of each portion easier. I added unit tests for these smaller functions to help catch potential issues with each. I left Test_processFilteredNodes as it serves well as a higher level test of all the other funtions.

This adjusts the thresholds for the even distribution of picking nodes when the cardinality is lower than the possible nodes. Due to the randomness, it is quite hard to test how evenly distributed the values are within the original thresholds. This would cause many intermittent test failures when the values were just over or under the thresholds.

This also moves the seed of math.Rand into the agent startup. Reseeding the randomness every function call seems like extra overhead for no value. I do not believe that constantly reseeding the randomness increases randomness in anyway.

This may help the tests for #967 