### PR TITLE
Add build target + improve test output

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -4,4 +4,4 @@ set -e
 docker build -t dkron .
 docker run dkron scripts/validate-gofmt
 docker run dkron go vet
-docker run --rm dkron go test -v ./... $1
+docker run --rm dkron go test -v ./... $1  | sed ''/PASS/s//$(printf "\033[32mPASS\033[0m")/'' | sed ''/FAIL/s//$(printf "\033[31mFAIL\033[0m")/''


### PR DESCRIPTION
Adds a make target for 'main' that rebuilds the main binary (and plugins) and any intermediates when necessary.
Colorize PASS or FAIL in test output to be able to easily spot the failures.