### PR TITLE
Control errors on scheduler start

### DIFF
--- a/dkron/scheduler.go
+++ b/dkron/scheduler.go
@@ -59,7 +59,9 @@ func (s *Scheduler) Start(jobs []*Job, agent *Agent) error {
 	metrics.IncrCounter([]string{"scheduler", "start"}, 1)
 	for _, job := range jobs {
 		job.Agent = agent
-		s.AddJob(job)
+		if err := s.AddJob(job); err != nil {
+			return err
+		}
 	}
 	s.Cron.Start()
 	s.started = true


### PR DESCRIPTION
Actually error if there's a problem starting the scheduler or adding jobs.

The purpose of this PR is to have proper error control and to trace down a sneaky issue where not all jobs are started.