### PR TITLE
Urls not working well in documentation page

### DIFF
--- a/website/content/usage/cron-spec.md
+++ b/website/content/usage/cron-spec.md
@@ -73,7 +73,7 @@ formatting the cron spec like this:
     @every <duration>
 
 where "duration" is a string accepted by time.ParseDuration
-(http://golang.org/pkg/time/#ParseDuration).
+(<http://golang.org/pkg/time/#ParseDuration>).
 
 For example, "@every 1h30m10s" would indicate a schedule that activates every
 1 hour, 30 minutes, 10 seconds.
@@ -90,7 +90,7 @@ formatting the cron spec like this:
     @at <datetime>
 
 Where "datetime" is a string accepted by time.Parse in RFC3339 format
-(https://golang.org/pkg/time/#Parse).
+(<https://golang.org/pkg/time/#Parse>).
 
 For example, "@at 2018-01-02T15:04:00Z" would run the job on the specified date and time
 assuming UTC timezone.
@@ -103,7 +103,7 @@ job definition.
 If the time zone is not specified, the following rules apply:
 
 All interpretation and scheduling is done in the machine's local time zone (as
-provided by the Go time package (http://www.golang.org/pkg/time).
+provided by the Go time package (<http://www.golang.org/pkg/time>).
 
 Be aware that jobs scheduled during daylight-savings leap-ahead transitions will
 not be run!


### PR DESCRIPTION
closing bracket was included in ulr forcing to copy it manually