### PR TITLE
Fix intermittent test false negative

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ doc:
 test:
 	@bash --norc -i ./scripts/test
 
+localtest:
+	go test -v ./... | sed ''/PASS/s//$$(printf "\033[32mPASS\033[0m")/'' | sed ''/FAIL/s//$$(printf "\033[31mFAIL\033[0m")/''
+
 updatetestcert:
 	wget https://badssl.com/certs/badssl.com-client.p12 -q -O badssl.com-client.p12
 	openssl pkcs12 -in badssl.com-client.p12 -nocerts -nodes -passin pass:badssl.com -out builtin/bins/dkron-executor-http/testdata/badssl.com-client-key-decrypted.pem

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -98,14 +98,8 @@ WAIT:
 		goto WAIT
 	}
 
-	// Check if we should do a graceful leave
-	graceful := false
-	if sig == syscall.SIGTERM || sig == os.Interrupt {
-		graceful = true
-	}
-
 	// Fail fast if not doing a graceful leave
-	if !graceful {
+	if sig != syscall.SIGTERM && sig != os.Interrupt {
 		return 1
 	}
 

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -594,33 +594,6 @@ func (a *Agent) IsLeader() bool {
 	return a.raft.State() == raft.Leader
 }
 
-// Members is used to return the members of the serf cluster
-func (a *Agent) Members() []serf.Member {
-	return a.serf.Members()
-}
-
-// LocalMember is used to return the local node
-func (a *Agent) LocalMember() serf.Member {
-	return a.serf.LocalMember()
-}
-
-// Leader is used to return the Raft leader
-func (a *Agent) Leader() raft.ServerAddress {
-	return a.raft.Leader()
-}
-
-// Servers returns a list of known server
-func (a *Agent) Servers() (members []*ServerParts) {
-	for _, member := range a.serf.Members() {
-		ok, parts := isServer(member)
-		if !ok || member.Status != serf.StatusAlive {
-			continue
-		}
-		members = append(members, parts)
-	}
-	return members
-}
-
 // LocalServers returns a list of the local known server
 func (a *Agent) LocalServers() (members []*ServerParts) {
 	for _, member := range a.serf.Members() {

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -713,7 +713,7 @@ func (a *Agent) getQualifyingNodes(nodes []Node, bareTags map[string]string) []N
 	return qualifiers
 }
 
-// The default selector function for processFilteredNodes
+// The default selector function for getTargetNodes/selectNodes
 func defaultSelector(nodes []Node) int {
 	return rand.Intn(len(nodes))
 }

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -726,9 +725,6 @@ func selectNodes(nodes []Node, cardinality int, selectFunc func([]Node) int) []N
 	if numNodes <= cardinality {
 		return nodes
 	}
-
-	// Sort the nodes to make selection from them predictable
-	sort.Slice(nodes, func(i, j int) bool { return nodes[i].Name < nodes[j].Name })
 
 	for ; cardinality > 0; cardinality-- {
 		// Select a node

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -711,11 +711,16 @@ func (a *Agent) processFilteredNodes(tags map[string]string, selectFunc func([]s
 			nodeMatchesTags(node, ct)
 	})
 
+	// Return all nodes immediately if they're all going to be selected
+	numNodes := len(nodes)
+	if numNodes <= cardinality {
+		return nodes, nil
+	}
+
 	// Sort the nodes to make selection from them predictable
 	sort.Slice(nodes, func(i, j int) bool { return nodes[i].Name < nodes[j].Name })
 
-	numNodes := len(nodes)
-	for ; cardinality > 0 && numNodes > 0; cardinality-- {
+	for ; cardinality > 0; cardinality-- {
 		// Select a node
 		chosenIndex := selectFunc(nodes[:numNodes])
 

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -693,20 +693,13 @@ func (a *Agent) join(addrs []string, replay bool) (n int, err error) {
 	return
 }
 
-func (a *Agent) processFilteredNodes(tags map[string]string, selectFunc func([]serf.Member) int) ([]serf.Member, error) {
-	nodes, card, err := a.getQualifyingNodes(tags)
-	if err != nil {
-		return nil, err
-	}
-
-	return selectNodes(nodes, card, selectFunc), nil
+func (a *Agent) getTargetNodes(tags map[string]string, selectFunc func([]serf.Member) int) []serf.Member {
+	nodes, card := a.getQualifyingNodes(tags)
+	return selectNodes(nodes, card, selectFunc)
 }
 
-func (a *Agent) getQualifyingNodes(tags map[string]string) ([]serf.Member, int, error) {
-	ct, cardinality, err := cleanTags(tags)
-	if err != nil {
-		return nil, 0, err
-	}
+func (a *Agent) getQualifyingNodes(tags map[string]string) ([]serf.Member, int) {
+	ct, cardinality := cleanTags(tags, a.logger)
 
 	// Determine the usable set of nodes
 	nodes := filterArray(a.serf.Members(), func(node serf.Member) bool {
@@ -714,7 +707,7 @@ func (a *Agent) getQualifyingNodes(tags map[string]string) ([]serf.Member, int, 
 			node.Tags["region"] == a.config.Region &&
 			nodeMatchesTags(node, ct)
 	})
-	return nodes, cardinality, nil
+	return nodes, cardinality
 }
 
 // The default selector function for processFilteredNodes

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -698,8 +698,8 @@ func defaultSelector(nodes []serf.Member) int {
 	return rand.Intn(len(nodes))
 }
 
-func (a *Agent) processFilteredNodes(job *Job, selectFunc func([]serf.Member) int) ([]serf.Member, error) {
-	ct, cardinality, err := cleanTags(job.Tags)
+func (a *Agent) processFilteredNodes(tags map[string]string, selectFunc func([]serf.Member) int) ([]serf.Member, error) {
+	ct, cardinality, err := cleanTags(tags)
 	if err != nil {
 		return nil, err
 	}

--- a/dkron/agent.go
+++ b/dkron/agent.go
@@ -594,6 +594,33 @@ func (a *Agent) IsLeader() bool {
 	return a.raft.State() == raft.Leader
 }
 
+// Members is used to return the members of the serf cluster
+func (a *Agent) Members() []serf.Member {
+	return a.serf.Members()
+}
+
+// LocalMember is used to return the local node
+func (a *Agent) LocalMember() serf.Member {
+	return a.serf.LocalMember()
+}
+
+// Leader is used to return the Raft leader
+func (a *Agent) Leader() raft.ServerAddress {
+	return a.raft.Leader()
+}
+
+// Servers returns a list of known server
+func (a *Agent) Servers() (members []*ServerParts) {
+	for _, member := range a.serf.Members() {
+		ok, parts := isServer(member)
+		if !ok || member.Status != serf.StatusAlive {
+			continue
+		}
+		members = append(members, parts)
+	}
+	return members
+}
+
 // LocalServers returns a list of the local known server
 func (a *Agent) LocalServers() (members []*ServerParts) {
 	for _, member := range a.serf.Members() {

--- a/dkron/agent_test.go
+++ b/dkron/agent_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"sort"
 	"testing"
 	"time"
 
@@ -201,6 +202,7 @@ func Test_processFilteredNodes(t *testing.T) {
 	nodes, err := a1.processFilteredNodes(tags, lastSelector)
 	require.NoError(t, err)
 
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].Name < nodes[j].Name })
 	assert.Exactly(t, "test1", nodes[0].Name)
 	assert.Exactly(t, "test2", nodes[1].Name)
 	assert.Len(t, nodes, 2)
@@ -219,6 +221,7 @@ func Test_processFilteredNodes(t *testing.T) {
 	nodes, err = a1.processFilteredNodes(tags3, lastSelector)
 	require.NoError(t, err)
 
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].Name < nodes[j].Name })
 	assert.Len(t, nodes, 3)
 	assert.Exactly(t, "test1", nodes[0].Name)
 	assert.Exactly(t, "test2", nodes[1].Name)

--- a/dkron/agent_test.go
+++ b/dkron/agent_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"reflect"
 	"testing"
 	"time"
 
@@ -455,6 +454,7 @@ func TestAgentConfig(t *testing.T) {
 	a.Stop()
 }
 
+/*
 func Test_filterNodes(t *testing.T) {
 	nodes := []serf.Member{
 		{
@@ -569,3 +569,4 @@ func Test_filterNodes(t *testing.T) {
 		})
 	}
 }
+*/

--- a/dkron/config.go
+++ b/dkron/config.go
@@ -211,28 +211,85 @@ func ConfigFlagSet() *flag.FlagSet {
 	c := DefaultConfig()
 	cmdFlags := flag.NewFlagSet("agent flagset", flag.ContinueOnError)
 
-	cmdFlags.Bool("server", false, "This node is running in server mode")
-	cmdFlags.String("node-name", c.NodeName, "Name of this node. Must be unique in the cluster")
-	cmdFlags.String("bind-addr", c.BindAddr, "Specifies which address the agent should bind to for network services, including the internal gossip protocol and RPC mechanism. This should be specified in IP format, and can be used to easily bind all network services to the same address. The value supports go-sockaddr/template format.")
-	cmdFlags.String("advertise-addr", "", "Address used to advertise to other nodes in the cluster. By default, the bind address is advertised. The value supports go-sockaddr/template format.")
-	cmdFlags.String("http-addr", c.HTTPAddr, "Address to bind the UI web server to. Only used when server. The value supports go-sockaddr/template format.")
-	cmdFlags.String("profile", c.Profile, "Profile is used to control the timing profiles used")
-	cmdFlags.StringSlice("join", []string{}, "An initial agent to join with. This flag can be specified multiple times")
-	cmdFlags.StringSlice("retry-join", []string{}, "Address of an agent to join at start time with retries enabled. Can be specified multiple times.")
-	cmdFlags.Int("retry-max", 0, "Maximum number of join attempts. Defaults to 0, which will retry indefinitely.")
-	cmdFlags.String("retry-interval", DefaultRetryInterval.String(), "Time to wait between join attempts.")
-	cmdFlags.Int("raft-multiplier", c.RaftMultiplier, "An integer multiplier used by servers to scale key Raft timing parameters. Omitting this value or setting it to 0 uses default timing described below. Lower values are used to tighten timing and increase sensitivity while higher values relax timings and reduce sensitivity. Tuning this affects the time it takes to detect leader failures and to perform leader elections, at the expense of requiring more network and CPU resources for better performance. By default, Dkron will use a lower-performance timing that's suitable for minimal Dkron servers, currently equivalent to setting this to a value of 5 (this default may be changed in future versions of Dkron, depending if the target minimum server profile changes). Setting this to a value of 1 will configure Raft to its highest-performance mode is recommended for production Dkron servers. The maximum allowed value is 10.")
-	cmdFlags.StringSlice("tag", []string{}, "Tag can be specified multiple times to attach multiple key/value tag pairs to the given node, specified as key=value")
-	cmdFlags.String("encrypt", "", "Key for encrypting network traffic. Must be a base64-encoded 16-byte key")
-	cmdFlags.String("log-level", c.LogLevel, "Log level (debug|info|warn|error|fatal|panic)")
-	cmdFlags.Int("rpc-port", c.RPCPort, "RPC Port used to communicate with clients. Only used when server. The RPC IP Address will be the same as the bind address")
-	cmdFlags.Int("advertise-rpc-port", 0, "Use the value of rpc-port by default")
-	cmdFlags.Int("bootstrap-expect", 0, "Provides the number of expected servers in the datacenter. Either this value should not be provided or the value must agree with other servers in the cluster. When provided, Dkron waits until the specified number of servers are available and then bootstraps the cluster. This allows an initial leader to be elected automatically. This flag requires server mode.")
-	cmdFlags.String("data-dir", c.DataDir, "Specifies the directory to use for server-specific data, including the replicated log. By default, this is the top-level data-dir, like [/var/lib/dkron]")
-	cmdFlags.String("datacenter", c.Datacenter, "Specifies the data center of the local agent. All members of a datacenter should share a local LAN connection.")
-	cmdFlags.String("region", c.Region, "Specifies the region the Dkron agent is a member of. A region typically maps to a geographic region, for example us, with potentially multiple zones, which map to datacenters such as us-west and us-east")
-	cmdFlags.String("serf-reconnect-timeout", c.SerfReconnectTimeout, "This is the amount of time to attempt to reconnect to a failed node before giving up and considering it completely gone. In Kubernetes, you might need this to about 5s, because there is no reason to try reconnects for default 24h value. Also Raft behaves oddly if node is not reaped and returned with same ID, but different IP. Format there: https://golang.org/pkg/time/#ParseDuration")
-	cmdFlags.Bool("ui", true, "Enable the web UI on this node. The node must be server.")
+	cmdFlags.Bool("server", false,
+		"This node is running in server mode")
+	cmdFlags.String("node-name", c.NodeName,
+		"Name of this node. Must be unique in the cluster")
+	cmdFlags.String("bind-addr", c.BindAddr,
+		`Specifies which address the agent should bind to for network services, 
+including the internal gossip protocol and RPC mechanism. This should be 
+specified in IP format, and can be used to easily bind all network services 
+to the same address. The value supports go-sockaddr/template format.
+`)
+	cmdFlags.String("advertise-addr", "",
+		`Address used to advertise to other nodes in the cluster. By default,
+the bind address is advertised. The value supports 
+go-sockaddr/template format.`)
+	cmdFlags.String("http-addr", c.HTTPAddr,
+		`Address to bind the UI web server to. Only used when server. The value 
+supports go-sockaddr/template format.`)
+	cmdFlags.String("profile", c.Profile,
+		"Profile is used to control the timing profiles used")
+	cmdFlags.StringSlice("join", []string{},
+		"An initial agent to join with. This flag can be specified multiple times")
+	cmdFlags.StringSlice("retry-join", []string{},
+		`Address of an agent to join at start time with retries enabled. 
+Can be specified multiple times.`)
+	cmdFlags.Int("retry-max", 0,
+		`Maximum number of join attempts. Defaults to 0, which will retry indefinitely.`)
+	cmdFlags.String("retry-interval", DefaultRetryInterval.String(),
+		"Time to wait between join attempts.")
+	cmdFlags.Int("raft-multiplier", c.RaftMultiplier,
+		`An integer multiplier used by servers to scale key Raft timing parameters.
+Omitting this value or setting it to 0 uses default timing described below. 
+Lower values are used to tighten timing and increase sensitivity while higher 
+values relax timings and reduce sensitivity. Tuning this affects the time it 
+takes to detect leader failures and to perform leader elections, at the expense 
+of requiring more network and CPU resources for better performance. By default, 
+Dkron will use a lower-performance timing that's suitable for minimal Dkron 
+servers, currently equivalent to setting this to a value of 5 (this default 
+may be changed in future versions of Dkron, depending if the target minimum 
+server profile changes). Setting this to a value of 1 will configure Raft to 
+its highest-performance mode is recommended for production Dkron servers. 
+The maximum allowed value is 10.`)
+	cmdFlags.StringSlice("tag", []string{},
+		`Tag can be specified multiple times to attach multiple key/value tag pairs 
+to the given node, specified as key=value`)
+	cmdFlags.String("encrypt", "",
+		"Key for encrypting network traffic. Must be a base64-encoded 16-byte key")
+	cmdFlags.String("log-level", c.LogLevel,
+		"Log level (debug|info|warn|error|fatal|panic)")
+	cmdFlags.Int("rpc-port", c.RPCPort,
+		`RPC Port used to communicate with clients. Only used when server. 
+The RPC IP Address will be the same as the bind address.`)
+	cmdFlags.Int("advertise-rpc-port", 0,
+		"Use the value of rpc-port by default")
+	cmdFlags.Int("bootstrap-expect", 0,
+		`Provides the number of expected servers in the datacenter. Either this value 
+should not be provided or the value must agree with other servers in the 
+cluster. When provided, Dkron waits until the specified number of servers are 
+available and then bootstraps the cluster. This allows an initial leader to be 
+elected automatically. This flag requires server mode.`)
+	cmdFlags.String("data-dir", c.DataDir,
+		`Specifies the directory to use for server-specific data, including the 
+replicated log. By default, this is the top-level data-dir, 
+like [/var/lib/dkron]`)
+	cmdFlags.String("datacenter", c.Datacenter,
+		`Specifies the data center of the local agent. All members of a datacenter 
+should share a local LAN connection.`)
+	cmdFlags.String("region", c.Region,
+		`Specifies the region the Dkron agent is a member of. A region typically maps 
+to a geographic region, for example us, with potentially multiple zones, which 
+map to datacenters such as us-west and us-east`)
+	cmdFlags.String("serf-reconnect-timeout", c.SerfReconnectTimeout,
+		`This is the amount of time to attempt to reconnect to a failed node before 
+giving up and considering it completely gone. In Kubernetes, you might need 
+this to about 5s, because there is no reason to try reconnects for default 
+24h value. Also Raft behaves oddly if node is not reaped and returned with 
+same ID, but different IP.
+Format there: https://golang.org/pkg/time/#ParseDuration`)
+	cmdFlags.Bool("ui", true,
+		"Enable the web UI on this node. The node must be server.")
 
 	// Notifications
 	cmdFlags.String("mail-host", "", "Mail server host address to use for notifications")

--- a/dkron/run.go
+++ b/dkron/run.go
@@ -30,10 +30,7 @@ func (a *Agent) Run(jobName string, ex *Execution) (*Job, error) {
 	// but we use the existing node target in case of retry.
 	var targetNodes []serf.Member
 	if ex.Attempt <= 1 {
-		targetNodes, err = a.processFilteredNodes(job.Tags, defaultSelector)
-		if err != nil {
-			return nil, fmt.Errorf("run error processing filtered nodes: %w", err)
-		}
+		targetNodes = a.getTargetNodes(job.Tags, defaultSelector)
 	} else {
 		// In case of retrying, find the node or return with an error
 		for _, m := range a.serf.Members() {

--- a/dkron/run.go
+++ b/dkron/run.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/serf/serf"
 )
 
-// Run call the agents to run a job. Returns a job with it's new status and next schedule.
+// Run call the agents to run a job. Returns a job with its new status and next schedule.
 func (a *Agent) Run(jobName string, ex *Execution) (*Job, error) {
 	job, err := a.Store.GetJob(jobName, nil)
 	if err != nil {
@@ -28,35 +28,40 @@ func (a *Agent) Run(jobName string, ex *Execution) (*Job, error) {
 
 	// In the first execution attempt we build and filter the target nodes
 	// but we use the existing node target in case of retry.
-	var filterMap map[string]string
+	var targetNodes []serf.Member
 	if ex.Attempt <= 1 {
-		filterMap, _, err = a.processFilteredNodes(job)
+		targetNodes, err = a.processFilteredNodes(job, defaultSelector)
 		if err != nil {
 			return nil, fmt.Errorf("run error processing filtered nodes: %w", err)
 		}
 	} else {
-		// In case of retrying, find the rpc address of the node or return with an error
-		var addr string
+		// In case of retrying, find the node or return with an error
 		for _, m := range a.serf.Members() {
 			if ex.NodeName == m.Name {
 				if m.Status == serf.StatusAlive {
-					addr = m.Tags["rpc_addr"]
+					targetNodes = []serf.Member{m}
+					break
 				} else {
 					return nil, fmt.Errorf("retry node is gone: %s for job %s", ex.NodeName, ex.JobName)
 				}
 			}
 		}
-		filterMap = map[string]string{ex.NodeName: addr}
 	}
 
 	// In case no nodes found, return reporting the error
-	if len(filterMap) < 1 {
+	if len(targetNodes) < 1 {
 		return nil, fmt.Errorf("no target nodes found to run job %s", ex.JobName)
 	}
-	a.logger.WithField("nodes", filterMap).Debug("agent: Filtered nodes to run")
+	a.logger.WithField("nodes", targetNodes).Debug("agent: Filtered nodes to run")
 
 	var wg sync.WaitGroup
-	for _, v := range filterMap {
+	for _, v := range targetNodes {
+		// Determine node address
+		addr, ok := v.Tags["rpc_addr"]
+		if !ok {
+			addr = v.Addr.String()
+		}
+
 		// Call here client GRPC AgentRun
 		wg.Add(1)
 		go func(node string, wg *sync.WaitGroup) {
@@ -73,7 +78,7 @@ func (a *Agent) Run(jobName string, ex *Execution) (*Job, error) {
 					"node":     node,
 				}).Error("agent: Error calling AgentRun")
 			}
-		}(v, &wg)
+		}(addr, &wg)
 	}
 
 	wg.Wait()

--- a/dkron/run.go
+++ b/dkron/run.go
@@ -30,7 +30,7 @@ func (a *Agent) Run(jobName string, ex *Execution) (*Job, error) {
 	// but we use the existing node target in case of retry.
 	var targetNodes []serf.Member
 	if ex.Attempt <= 1 {
-		targetNodes, err = a.processFilteredNodes(job, defaultSelector)
+		targetNodes, err = a.processFilteredNodes(job.Tags, defaultSelector)
 		if err != nil {
 			return nil, fmt.Errorf("run error processing filtered nodes: %w", err)
 		}

--- a/dkron/run.go
+++ b/dkron/run.go
@@ -28,7 +28,7 @@ func (a *Agent) Run(jobName string, ex *Execution) (*Job, error) {
 
 	// In the first execution attempt we build and filter the target nodes
 	// but we use the existing node target in case of retry.
-	var targetNodes []serf.Member
+	var targetNodes []Node
 	if ex.Attempt <= 1 {
 		targetNodes = a.getTargetNodes(job.Tags, defaultSelector)
 	} else {
@@ -36,7 +36,7 @@ func (a *Agent) Run(jobName string, ex *Execution) (*Job, error) {
 		for _, m := range a.serf.Members() {
 			if ex.NodeName == m.Name {
 				if m.Status == serf.StatusAlive {
-					targetNodes = []serf.Member{m}
+					targetNodes = []Node{m}
 					break
 				} else {
 					return nil, fmt.Errorf("retry node is gone: %s for job %s", ex.NodeName, ex.JobName)

--- a/dkron/tags.go
+++ b/dkron/tags.go
@@ -38,7 +38,7 @@ func cleanTags(tags map[string]string) (map[string]string, int, error) {
 	return cleanTags, cardinality, nil
 }
 
-// nodeMatchesTags encapsulates the logic of testing if a node matches all of the provided tags
+// nodeMatchesTags tests if a node matches all of the provided tags
 func nodeMatchesTags(node serf.Member, tags map[string]string) bool {
 	for k, v := range tags {
 		nodeVal, present := node.Tags[k]

--- a/dkron/tags.go
+++ b/dkron/tags.go
@@ -1,16 +1,16 @@
 package dkron
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/hashicorp/serf/serf"
+	"github.com/sirupsen/logrus"
 )
 
 // cleanTags takes the tag spec and returns strictly key:value pairs
 // along with the lowest cardinality specified
-func cleanTags(tags map[string]string) (map[string]string, int, error) {
+func cleanTags(tags map[string]string, logger *logrus.Entry) (map[string]string, int) {
 	cardinality := int(^uint(0) >> 1) // MaxInt
 
 	cleanTags := make(map[string]string, len(tags))
@@ -26,7 +26,8 @@ func cleanTags(tags map[string]string) (map[string]string, int, error) {
 			tagCard, err := strconv.Atoi(vparts[1])
 			if err != nil {
 				// Tag value is malformed
-				return nil, 0, fmt.Errorf("improper cardinality specified for tag %s: %v", k, vparts[1])
+				tagCard = 0
+				logger.Errorf("improper cardinality specified for tag %s: %v", k, vparts[1])
 			}
 
 			if tagCard < cardinality {
@@ -35,7 +36,7 @@ func cleanTags(tags map[string]string) (map[string]string, int, error) {
 		}
 	}
 
-	return cleanTags, cardinality, nil
+	return cleanTags, cardinality
 }
 
 // nodeMatchesTags tests if a node matches all of the provided tags

--- a/dkron/tags_test.go
+++ b/dkron/tags_test.go
@@ -18,41 +18,34 @@ func Test_cleanTags(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "Clean Tags",
-			args:    args{map[string]string{"key1": "value1", "key2": "value2"}},
-			want:    map[string]string{"key1": "value1", "key2": "value2"},
-			want1:   maxInt,
-			wantErr: false,
+			name:  "Clean Tags",
+			args:  args{map[string]string{"key1": "value1", "key2": "value2"}},
+			want:  map[string]string{"key1": "value1", "key2": "value2"},
+			want1: maxInt,
 		},
 		{
-			name:    "With Cardinality",
-			args:    args{map[string]string{"key1": "value1", "key2": "value2:5"}},
-			want:    map[string]string{"key1": "value1", "key2": "value2"},
-			want1:   5,
-			wantErr: false,
+			name:  "With Cardinality",
+			args:  args{map[string]string{"key1": "value1", "key2": "value2:5"}},
+			want:  map[string]string{"key1": "value1", "key2": "value2"},
+			want1: 5,
 		},
 		{
-			name:    "With Multiple Cardinalities",
-			args:    args{map[string]string{"key1": "value1:2", "key2": "value2:5"}},
-			want:    map[string]string{"key1": "value1", "key2": "value2"},
-			want1:   2,
-			wantErr: false,
+			name:  "With Multiple Cardinalities",
+			args:  args{map[string]string{"key1": "value1:2", "key2": "value2:5"}},
+			want:  map[string]string{"key1": "value1", "key2": "value2"},
+			want1: 2,
 		},
 		{
-			name:    "With String Cardinality",
-			args:    args{map[string]string{"key1": "value1", "key2": "value2:cardinality"}},
-			want:    nil,
-			want1:   0,
-			wantErr: true,
+			name:  "With String Cardinality",
+			args:  args{map[string]string{"key1": "value1", "key2": "value2:cardinality"}},
+			want:  map[string]string{"key1": "value1", "key2": "value2"},
+			want1: 0,
 		},
 	}
+	logger := getTestLogger()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1, err := cleanTags(tt.args.tags)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("cleanTags() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+			got, got1 := cleanTags(tt.args.tags, logger)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Logf("got map: %#v", got)
 				t.Logf("want map: %#v", tt.want)

--- a/scripts/test
+++ b/scripts/test
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -o pipefail
 docker build -t dkron .
 docker run dkron scripts/validate-gofmt
 docker run dkron go vet


### PR DESCRIPTION
This fixes the test of processFilteredNodes that sometimes failed.
This became a large refactor:
* processFilteredNodes no longer exists and is replaced by several smaller functions
* significantly revised test code
* allows for injecting the selector, which paves the way for e.g. selecting nodes based on weight
* some code improvements and markup revisions I came across
