### PR TITLE
fix notification bug

### DIFF
--- a/dkron/notifier.go
+++ b/dkron/notifier.go
@@ -69,7 +69,11 @@ func (n *Notifier) report() string {
 }
 
 func (n *Notifier) buildTemplate(templ string, logger *logrus.Entry) *bytes.Buffer {
-	t := template.Must(template.New("report").Parse(templ))
+	t, e := template.New("report").Parse(templ)
+	if e != nil {
+		logger.WithError(e).Error("notifier: error parsing template")
+		return bytes.NewBuffer([]byte("Failed to parse template: " + e.Error()))
+	}
 
 	data := struct {
 		Report        string


### PR DESCRIPTION
The notification template are valided at notification time with a
"Must" function. So, if the templte is wrong, the final user get a
panic/backtrace like the floowing.

This patch fix this behavior, it compiles the template, catch the
error and retirn the error in the generated message (like processing
errors)

this ensure the service continue working, even if notification were wrong.

Jun 22 11:18:26 batch03 dkron[56662]: panic: template: report:1: function "JSEscaper" not defined
Jun 22 11:18:26 batch03 dkron[56662]: goroutine 293 [running]:
Jun 22 11:18:26 batch03 dkron[56662]: text/template.Must(...)
Jun 22 11:18:26 batch03 dkron[56662]:         /usr/local/go/src/text/template/helper.go:25
Jun 22 11:18:26 batch03 dkron[56662]: github.com/distribworks/dkron/v3/dkron.(*Notifier).buildTemplate(0xc00121ce70, 0xc000381ae0, 0x98, 0xc0001e8e70, 0x18)
Jun 22 11:18:26 batch03 dkron[56662]:         /Users/thierryfournier/git/ext/dkron/dkron/notifier.go:72 +0x6bc
Jun 22 11:18:26 batch03 dkron[56662]: github.com/distribworks/dkron/v3/dkron.(*Notifier).callExecutionWebhook(0xc00121ce70, 0xc0001e8e70, 0x0, 0x0)
Jun 22 11:18:26 batch03 dkron[56662]:         /Users/thierryfournier/git/ext/dkron/dkron/notifier.go:137 +0x86
Jun 22 11:18:26 batch03 dkron[56662]: github.com/distribworks/dkron/v3/dkron.(*Notifier).Send(0xc00121ce70, 0xc0001e8e70, 0xc0011b6450, 0xc000e8c468)
Jun 22 11:18:26 batch03 dkron[56662]:         /Users/thierryfournier/git/ext/dkron/dkron/notifier.go:42 +0x85
Jun 22 11:18:26 batch03 dkron[56662]: github.com/distribworks/dkron/v3/dkron.(*GRPCServer).ExecutionDone(0xc000ec2660, 0x331caf8, 0xc0011897a0, 0xc0011897d0, 0x0, 0x0, 0x0)
Jun 22 11:18:26 batch03 dkron[56662]:         /Users/thierryfournier/git/ext/dkron/dkron/grpc.go:240 +0x1495
Jun 22 11:18:26 batch03 dkron[56662]: github.com/distribworks/dkron/v3/plugin/types._Dkron_ExecutionDone_Handler(0x2415f40, 0xc000ec2660, 0x331caf8, 0xc0011897a0, 0xc0014b2c60, 0x0, 0x331caf8, 0xc0011897a0, 0xc001481980, 0x57)
Jun 22 11:18:26 batch03 dkron[56662]:         /Users/thierryfournier/git/ext/dkron/plugin/types/dkron_grpc.pb.go:233 +0x214
Jun 22 11:18:26 batch03 dkron[56662]: google.golang.org/grpc.(*Server).processUnaryRPC(0xc000d721c0, 0x3333ad8, 0xc001146780, 0xc0008b6240, 0xc000ecc1e0, 0x4278258, 0x0, 0x0, 0x0)
Jun 22 11:18:26 batch03 dkron[56662]:         /Users/thierryfournier/go/pkg/mod/google.golang.org/grpc@v1.37.0/server.go:1217 +0x52b
Jun 22 11:18:26 batch03 dkron[56662]: google.golang.org/grpc.(*Server).handleStream(0xc000d721c0, 0x3333ad8, 0xc001146780, 0xc0008b6240, 0x0)
Jun 22 11:18:26 batch03 dkron[56662]:         /Users/thierryfournier/go/pkg/mod/google.golang.org/grpc@v1.37.0/server.go:1540 +0xd0c
Jun 22 11:18:26 batch03 dkron[56662]: google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc00117e810, 0xc000d721c0, 0x3333ad8, 0xc001146780, 0xc0008b6240)
Jun 22 11:18:26 batch03 dkron[56662]:         /Users/thierryfournier/go/pkg/mod/google.golang.org/grpc@v1.37.0/server.go:878 +0xab
Jun 22 11:18:26 batch03 dkron[56662]: created by google.golang.org/grpc.(*Server).serveStreams.func1
Jun 22 11:18:26 batch03 dkron[56662]:         /Users/thierryfournier/go/pkg/mod/google.golang.org/grpc@v1.37.0/server.go:876 +0x1fd