### PR TITLE
use relative API_URL

### DIFF
--- a/dkron/ui.go
+++ b/dkron/ui.go
@@ -81,7 +81,7 @@ func (h *HTTPTransport) UI(r *gin.RouterGroup) {
 				ln = l.Name
 			}
 			ctx.HTML(http.StatusOK, "index.html", gin.H{
-				"DKRON_API_URL":          fmt.Sprintf("/%s", apiPathPrefix),
+				"DKRON_API_URL":          fmt.Sprintf("../%s", apiPathPrefix),
 				"DKRON_LEADER":           ln,
 				"DKRON_TOTAL_JOBS":       totalJobs,
 				"DKRON_FAILED_JOBS":      failedJobs,


### PR DESCRIPTION
Similar to a PR I've done in a past version (v1 already I think) for the old UI, this would allow to serve dkron behind a reverse proxy on a custom path.

I've gone through the code (not extensively) looking for places where DKRON_API_URL would be loaded from a different path but I couldn't find any (mostly as it's all react now).