### PR TITLE
bugfix: panic or network errors

### DIFF
--- a/plugin/executor.go
+++ b/plugin/executor.go
@@ -62,7 +62,10 @@ func (m *ExecutorClient) Execute(args *types.ExecuteRequest, cb StatusHelper) (*
 	args.StatusServer = brokerID
 	r, err := m.client.Execute(context.Background(), args)
 
-	s.Stop()
+	/* In some cases the server cannot start (ex: too many open files), so, the s pointer is nil */
+	if s != nil {
+		s.Stop()
+	}
 	return r, err
 }
 


### PR DESCRIPTION
In some cases the server cannot start (ex: too many open files), so, the s pointer is nil

A backtrace ewample:

```
   panic: runtime error: invalid memory address or nil pointer dereference
   [signal SIGSEGV: segmentation violation code=0x1 addr=0x168 pc=0x157fa8a]

   goroutine 5069 [running]:
   google.golang.org/grpc.(*Server).Stop(0x0)
      /Users/thierry/go/pkg/mod/google.golang.org/grpc@v1.37.0/server.go:1626 +0x4a
   github.com/distribworks/dkron/v3/plugin.(*ExecutorClient).Execute(0xc00011ac90, 0xc00363ab90, 0x3ef9020, 0xc000625818, 0xc003511b00, 0xc0010f1401, 0x203000)
      /Users/thierry/git/ext/dkron/plugin/executor.go:65 +0x198
   github.com/distribworks/dkron/v3/dkron.(*AgentServer).AgentRun(0xc000c1f240, 0xc0015b9040, 0x3f49a38, 0xc001241f60, 0x0, 0x0)
      /Users/thierry/git/ext/dkron/dkron/grpc_agent.go:87 +0x710
   github.com/distribworks/dkron/v3/plugin/types._Agent_AgentRun_Handler(0x2d3bbc0, 0xc000c1f240, 0x3f44de0, 0xc00026cc00, 0x4ef8580, 0xc003534240)
      /Users/thierry/git/ext/dkron/plugin/types/dkron_grpc.pb.go:540 +0x113
   google.golang.org/grpc.(*Server).processStreamingRPC(0xc0005c2700, 0x3f4fd58, 0xc00235ec00, 0xc003534240, 0xc000d3cb70, 0x4e8d720, 0x0, 0x0, 0x0)
      /Users/thierry/go/pkg/mod/google.golang.org/grpc@v1.37.0/server.go:1464 +0xcd8
   google.golang.org/grpc.(*Server).handleStream(0xc0005c2700, 0x3f4fd58, 0xc00235ec00, 0xc003534240, 0x0)
      /Users/thierry/go/pkg/mod/google.golang.org/grpc@v1.37.0/server.go:1544 +0xca5
   google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc002e227c0, 0xc0005c2700, 0x3f4fd58, 0xc00235ec00, 0xc003534240)
      /Users/thierry/go/pkg/mod/google.golang.org/grpc@v1.37.0/server.go:878 +0xab
   created by google.golang.org/grpc.(*Server).serveStreams.func1
      /Users/thierry/go/pkg/mod/google.golang.org/grpc@v1.37.0/server.go:876 +0x1fd
```