### PR TITLE
hot fix: nats executor consume all available connections fixes

### DIFF
--- a/builtin/bins/dkron-executor-nats/nats.go
+++ b/builtin/bins/dkron-executor-nats/nats.go
@@ -73,6 +73,11 @@ func (s *Nats) ExecuteImpl(args *dktypes.ExecuteRequest) ([]byte, error) {
 	if debug {
 		log.Printf("request  %#v\n\n", nc)
 	}
+	
+	if nc.IsConnected() {
+		defer nc.Flush()
+		defer nc.Close()
+	}
 
 	return output.Bytes(), nil
 }


### PR DESCRIPTION
adding defer option to close opened nats connection
this commit fixes #1019