### PR TITLE
Allow passing through a message key for Kafka executor

### DIFF
--- a/builtin/bins/dkron-executor-kafka/kafka.go
+++ b/builtin/bins/dkron-executor-kafka/kafka.go
@@ -26,6 +26,7 @@ type Kafka struct {
 // "executor": "kafka",
 // "executor_config": {
 //     "brokerAddress": "192.168.59.103:9092", // kafka broker url
+//     "key": "",
 //     "message": "",
 //     "topic": "publishTopic"
 // }
@@ -78,6 +79,7 @@ func (s *Kafka) ExecuteImpl(args *dktypes.ExecuteRequest) ([]byte, error) {
 
 	msg := &sarama.ProducerMessage{
 		Topic: args.Config["topic"],
+		Key: sarama.StringEncoder(args.Config["key"]),
 		Value: sarama.StringEncoder(args.Config["message"]),
 	}
 

--- a/builtin/bins/dkron-executor-kafka/kafka_test.go
+++ b/builtin/bins/dkron-executor-kafka/kafka_test.go
@@ -7,9 +7,29 @@ import (
 	dktypes "github.com/distribworks/dkron/v3/plugin/types"
 )
 
-func TestProduceExecute(t *testing.T) {
+func TestProduceExecuteWithKey(t *testing.T) {
 	pa := &dktypes.ExecuteRequest{
-		JobName: "testJob",
+		JobName: "testJobWithKey",
+		Config: map[string]string{
+			"topic":         "test",
+			"brokerAddress": "testaddress",
+			"key":           "testkey",
+			"message":       "{\"hello\":11}",
+			"debug":         "true",
+		},
+	}
+	kafka := &Kafka{}
+	output, err := kafka.Execute(pa, nil)
+	fmt.Println(string(output.Output))
+	fmt.Println(err)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestProduceExecuteWithoutKey(t *testing.T) {
+	pa := &dktypes.ExecuteRequest{
+		JobName: "testJobWithoutKey",
 		Config: map[string]string{
 			"topic":         "test",
 			"brokerAddress": "testaddress",

--- a/website/content/usage/executors/kafka.md
+++ b/website/content/usage/executors/kafka.md
@@ -23,7 +23,7 @@ Example
 "executor": "kafka",
 "executor_config": {
     "brokerAddress": "localhost:9092",
-    "key": "MyKey",
+    "key": "My key",
     "message": "My message",
     "topic": "my_topic"
 }

--- a/website/content/usage/executors/kafka.md
+++ b/website/content/usage/executors/kafka.md
@@ -11,7 +11,8 @@ Params
 
 ```
 brokerAddress: "IP:port" of the broker
-message:       The message to produce
+key:           The key of the message to produce
+message:       The body of the message to produce
 topic:         The Kafka topic for this message
 debug:         Turns on debugging output if not empty
 ```

--- a/website/content/usage/executors/kafka.md
+++ b/website/content/usage/executors/kafka.md
@@ -22,6 +22,7 @@ Example
 "executor": "kafka",
 "executor_config": {
     "brokerAddress": "localhost:9092",
+    "key": "MyKey",
     "message": "My message",
     "topic": "my_topic"
 }


### PR DESCRIPTION
Enable the ability to use a message key in the Kafka executor. The key is fairly useful/core functionality for Kafka: 
- https://stackoverflow.com/a/29515696
- https://stackoverflow.com/a/61912094