### PR TITLE
truncate execution output in default view

### DIFF
--- a/dkron/api.go
+++ b/dkron/api.go
@@ -119,7 +119,7 @@ func (h *HTTPTransport) APIRoutes(r *gin.RouterGroup, middleware ...gin.HandlerF
 	// Place fallback routes last
 	jobs.GET("/:job", h.jobGetHandler)
 	jobs.GET("/:job/executions", h.executionsHandler)
-	jobs.GET("/:job/execution/:execution", h.executionHandler)
+	jobs.GET("/:job/executions/:execution", h.executionHandler)
 }
 
 // MetaMiddleware adds middleware to the gin Context.

--- a/dkron/api.go
+++ b/dkron/api.go
@@ -337,9 +337,9 @@ func (h *HTTPTransport) executionsHandler(c *gin.Context) {
 		sort = "started_at"
 	}
 	order := c.DefaultQuery("_order", "DESC")
-	output_size, err := strconv.Atoi(c.DefaultQuery("output_size", ""))
+	output_size_limit, err := strconv.Atoi(c.DefaultQuery("output_size_limit", ""))
 	if err != nil {
-		output_size = -1
+		output_size_limit = -1
 	}
 
 	job, err := h.agent.Store.GetJob(jobName, nil)
@@ -362,12 +362,12 @@ func (h *HTTPTransport) executionsHandler(c *gin.Context) {
 		return
 	}
 
-	if output_size > 0 {
+	if output_size_limit > 0 {
 		// truncate execution output
 		for _, execution := range executions {
 			_s := len(execution.Output)
-			if _s > output_size {
-				execution.Output = execution.Output[_s-output_size:]
+			if _s > output_size_limit {
+				execution.Output = execution.Output[_s-output_size_limit:]
 			}
 		}
 	}

--- a/dkron/api.go
+++ b/dkron/api.go
@@ -365,9 +365,9 @@ func (h *HTTPTransport) executionsHandler(c *gin.Context) {
 	if output_size_limit > 0 {
 		// truncate execution output
 		for _, execution := range executions {
-			_s := len(execution.Output)
-			if _s > output_size_limit {
-				execution.Output = execution.Output[_s-output_size_limit:]
+			size := len(execution.Output)
+			if size > output_size_limit {
+				execution.Output = execution.Output[size-output_size_limit:]
 			}
 		}
 	}

--- a/dkron/api.go
+++ b/dkron/api.go
@@ -371,14 +371,15 @@ func (h *HTTPTransport) executionsHandler(c *gin.Context) {
 	for j, execution := range executions {
 		apiExecutions[j] = &apiExecution{execution, false}
 		if outputSizeLimit > -1 {
-			apiExecutions[j].OutputTruncated = true
 			// truncate execution output
 			if outputSizeLimit == 0 {
 				apiExecutions[j].Output = ""
+				apiExecutions[j].OutputTruncated = true
 			} else {
 				size := len(execution.Output)
 				if size > outputSizeLimit {
 					apiExecutions[j].Output = apiExecutions[j].Output[size-outputSizeLimit:]
+					apiExecutions[j].OutputTruncated = true
 				}
 			}
 		}

--- a/dkron/api.go
+++ b/dkron/api.go
@@ -372,15 +372,10 @@ func (h *HTTPTransport) executionsHandler(c *gin.Context) {
 		apiExecutions[j] = &apiExecution{execution, false}
 		if outputSizeLimit > -1 {
 			// truncate execution output
-			if outputSizeLimit == 0 {
-				apiExecutions[j].Output = ""
+			size := len(execution.Output)
+			if size > outputSizeLimit {
+				apiExecutions[j].Output = apiExecutions[j].Output[size-outputSizeLimit:]
 				apiExecutions[j].OutputTruncated = true
-			} else {
-				size := len(execution.Output)
-				if size > outputSizeLimit {
-					apiExecutions[j].Output = apiExecutions[j].Output[size-outputSizeLimit:]
-					apiExecutions[j].OutputTruncated = true
-				}
 			}
 		}
 	}

--- a/ui/src/dataProvider.ts
+++ b/ui/src/dataProvider.ts
@@ -18,7 +18,7 @@ const myDataProvider = {
             _order: order,
             _start: (page - 1) * perPage,
             _end: page * perPage,
-            output_size: 200,
+            output_size_limit: 200,
         };
         const url = `${apiUrl}/${params.target}/${params.id}/${resource}?${stringify(query)}`;
 

--- a/ui/src/dataProvider.ts
+++ b/ui/src/dataProvider.ts
@@ -18,6 +18,7 @@ const myDataProvider = {
             _order: order,
             _start: (page - 1) * perPage,
             _end: page * perPage,
+            output_size: 200,
         };
         const url = `${apiUrl}/${params.target}/${params.id}/${resource}?${stringify(query)}`;
 

--- a/ui/src/jobs/JobShow.tsx
+++ b/ui/src/jobs/JobShow.tsx
@@ -43,7 +43,7 @@ const FullButton = ({record}: any) => {
     const handleClick = () => {
         setLoading(true);
         dispatch(fetchStart()); // start the global loading indicator 
-        fetch(`${apiUrl}/jobs/${record.job_name}/execution/${record.id}`)
+        fetch(`${apiUrl}/jobs/${record.job_name}/executions/${record.id}`)
             .then((response) => {
                 if (response.ok) {
                     notify('Success loading full output');

--- a/ui/src/jobs/JobShow.tsx
+++ b/ui/src/jobs/JobShow.tsx
@@ -52,6 +52,7 @@ const FullButton = ({record}: any) => {
                 throw response
             })
             .then((data) => {
+                record.output_truncated = false
                 record.output = data.output
             })
             .catch((e) => {
@@ -74,8 +75,12 @@ const FullButton = ({record}: any) => {
 };
 
 const SpecialOutputPanel = ({ id, record, resource }: any) => {
-    // FIXME: hide button if not required
-    return (<div className="execution-output"><div><FullButton record={record} /></div>{record.output || "Empty output"}</div>);
+    return (
+        <div className="execution-output">
+            {record.output_truncated ? <div><FullButton record={record} /></div> : ""}
+            {record.output || "Empty output"}
+        </div>
+    );
 };
 
 const JobShow = (props: any) => (

--- a/ui/src/jobs/JobShow.tsx
+++ b/ui/src/jobs/JobShow.tsx
@@ -11,14 +11,18 @@ import {
     TabbedShowLayout,
     Tab,
     ReferenceManyField,
+    useNotify, useRedirect, fetchStart, fetchEnd, Button,
 } from 'react-admin';
-import { OutputPanel } from "../executions/BusyList";
 import ToggleButton from "./ToggleButton"
 import RunButton from "./RunButton"
 import { JsonField } from "react-admin-json-view";
 import ZeroDateField from "./ZeroDateField";
 import JobIcon from '@material-ui/icons/Update';
+import FullIcon from '@material-ui/icons/BatteryFull';
 import { Tooltip } from '@material-ui/core';
+import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { apiUrl } from '../dataProvider';
 
 const JobShowActions = ({ basePath, data, resource }: any) => (
     <TopToolbar>
@@ -30,6 +34,48 @@ const JobShowActions = ({ basePath, data, resource }: any) => (
 
 const SuccessField = (props: any) => {
     return (props.record["finished_at"] === null ? <Tooltip title="Running"><JobIcon /></Tooltip> : <BooleanField {...props} />);
+};
+
+const FullButton = ({record}: any) => {
+    const dispatch = useDispatch();
+    const notify = useNotify();
+    const [loading, setLoading] = useState(false);
+    const handleClick = () => {
+        setLoading(true);
+        dispatch(fetchStart()); // start the global loading indicator 
+        fetch(`${apiUrl}/jobs/${record.job_name}/execution/${record.id}`)
+            .then((response) => {
+                if (response.ok) {
+                    notify('Success loading full output');
+                    return response.json()
+                }
+                throw response
+            })
+            .then((data) => {
+                record.output = data.output
+            })
+            .catch((e) => {
+                notify('Error on loading full output', 'warning')
+            })
+            .finally(() => {
+                setLoading(false);
+                dispatch(fetchEnd()); // stop the global loading indicator
+            });
+    };
+    return (
+        <Button 
+            label="Load full output"
+            onClick={handleClick}
+            disabled={loading}
+        >
+            <FullIcon/>
+        </Button>
+    );
+};
+
+const SpecialOutputPanel = ({ id, record, resource }: any) => {
+    // FIXME: hide button if not required
+    return (<div className="execution-output"><div><FullButton record={record} /></div>{record.output || "Empty output"}</div>);
 };
 
 const JobShow = (props: any) => (
@@ -82,7 +128,7 @@ const JobShow = (props: any) => (
             </Tab>
             <Tab label="executions" path="executions">
                 <ReferenceManyField reference="executions" target="jobs" label="Executions">
-                    <Datagrid rowClick="expand" isRowSelectable={ record => false } expand={<OutputPanel {...props} />}>
+                    <Datagrid rowClick="expand" isRowSelectable={ record => false } expand={<SpecialOutputPanel {...props} />}>
                         <TextField source="id" />
                         <TextField source="group" sortable={false} />
                         <TextField source="job_name" sortable={false} />

--- a/ui/src/jobs/JobShow.tsx
+++ b/ui/src/jobs/JobShow.tsx
@@ -78,7 +78,7 @@ const SpecialOutputPanel = ({ id, record, resource }: any) => {
     return (
         <div className="execution-output">
             {record.output_truncated ? <div><FullButton record={record} /></div> : ""}
-            {record.output || "Empty output"}
+            {record.output || "Nothing to show"}
         </div>
     );
 };


### PR DESCRIPTION
`maxBufSize = 256000` in the shell handler, 100 executions per job, 25M to download when listing executions (and added browser rendering time)

The idea of this PR is to add an API parameter to truncate execution output but leave default to not truncate and avoid API breaking changes.

Then update UI to load list truncated but allow individual executions to have output fully loaded.

## test

Create job with shell command `seq 1000000` (`seq 1000000 | wc -c` = `6888894`)

```
curl 'http://localhost:8080/v1/jobs' \
     --data-raw '{"name":"test","schedule":"@manually","executor":"shell","executor_config":{"command":"seq 1000000"}}'
```

Run it 100+ times:

```
for i in $(seq 100); do curl 'http://localhost:8080/v1/jobs/test' -X POST; done
```

## Notes

Some parts pending re-design as I'm a complete react ignorant:

* This PR does not include the generated assets to allow for a cleaner review first
* `output_size` was added to dataprovider though it doesn't look correct there - how to send extra query param (`output_size`) from the ReferenceManyField component without modifying dataprovider? Or modifying it in a more generic way that makes sense to other components/resources
* `SpecialOutputPanel` hammered in to have the `load full output` button, any suggestion for better UI/code? also need(should?) hide button if output is not truncated
* missing tests for the new api endpoint (left for after initial review/comments)
