### PR TITLE
refresh current page after toggle/run job is used

### DIFF
--- a/ui/src/jobs/RunButton.tsx
+++ b/ui/src/jobs/RunButton.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { useNotify, useRedirect, fetchStart, fetchEnd, Button } from 'react-admin';
+import { useNotify, useRefresh, fetchStart, fetchEnd, Button } from 'react-admin';
 import { apiUrl } from '../dataProvider';
 import RunIcon from '@material-ui/icons/PlayArrow';
 
 const RunButton = ({record}: any) => {
     const dispatch = useDispatch();
-    const redirect = useRedirect();
+    const refresh = useRefresh();
     const notify = useNotify();
     const [loading, setLoading] = useState(false);
     const handleClick = () => {
@@ -16,7 +16,7 @@ const RunButton = ({record}: any) => {
         fetch(`${apiUrl}/jobs/${record.id}`, { method: 'POST' })
             .then(() => {
                 notify('Success running job');
-                redirect('/jobs');
+                refresh();
             })
             .catch((e) => {
                 notify('Error on running job', 'warning')

--- a/ui/src/jobs/ToggleButton.tsx
+++ b/ui/src/jobs/ToggleButton.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { useNotify, useRedirect, fetchStart, fetchEnd, Button } from 'react-admin';
+import { useNotify, useRefresh, fetchStart, fetchEnd, Button } from 'react-admin';
 import { apiUrl } from '../dataProvider';
 import ToggleIcon from '@material-ui/icons/Pause';
 
 const ToggleButton = ({record}: any) => {
     const dispatch = useDispatch();
-    const redirect = useRedirect();
+    const refresh = useRefresh();
     const notify = useNotify();
     const [loading, setLoading] = useState(false);
     const handleClick = () => {
@@ -16,7 +16,7 @@ const ToggleButton = ({record}: any) => {
         fetch(`${apiUrl}/jobs/${record.id}/toggle`, { method: 'POST' })
             .then(() => {
                 notify('Job toggled');
-                redirect('/jobs');
+                refresh();
             })
             .catch((e) => {
                 notify('Error on toggle job', 'warning')


### PR DESCRIPTION
IMO, this allows a much nicer UX.

if I'm looking at show page of a job and click `run`, most of the time I'd like to continue in that page.
If I do want to go back to jobs list, it's just one click after the refresh. With the current redirect, the opposite use case does not take one single click but instead typing job name again (assuming decent list of jobs) and opening it.

Not sure about the toggle button, but I guess it'd make sense to do the same.

For the edit button it'd be great to do the same but I've been unable to properly get job id into a `redirect` for `JobEdit`/`EditForm`