### PR TITLE
supported terraform provider link

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ PHP client
 https://github.com/gromo/dkron-php-adapter
 
 Terraform provider
-https://github.com/peertransfer/terraform-provider-dkron
+https://github.com/bozerkins/terraform-provider-dkron
 
 ## Get in touch
 


### PR DESCRIPTION
Hello! 

Created a new terraform provider for dkron and just wanted to add it to the docs. I'd happy to contribute more to the provider and overall but would need to make myself familiar with dkron roadmap and overall plans for development.

Cheers!