### PR TITLE
Allow multiple brokers in kafka executor

### DIFF
--- a/builtin/bins/dkron-executor-kafka/kafka.go
+++ b/builtin/bins/dkron-executor-kafka/kafka.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"log"
+	"strings"
 
 	"github.com/Shopify/sarama"
 	"github.com/armon/circbuf"
@@ -65,7 +66,7 @@ func (s *Kafka) ExecuteImpl(args *dktypes.ExecuteRequest) ([]byte, error) {
 	config.Producer.Return.Successes = true
 	config.Producer.Return.Errors = true
 
-	brokers := []string{args.Config["brokerAddress"]}
+	brokers := strings.Split(args.Config["brokerAddress"], ",")
 	producer, err := sarama.NewSyncProducer(brokers, config)
 	if err != nil {
 		// Should not reach here
@@ -79,7 +80,7 @@ func (s *Kafka) ExecuteImpl(args *dktypes.ExecuteRequest) ([]byte, error) {
 
 	msg := &sarama.ProducerMessage{
 		Topic: args.Config["topic"],
-		Key: sarama.StringEncoder(args.Config["key"]),
+		Key:   sarama.StringEncoder(args.Config["key"]),
 		Value: sarama.StringEncoder(args.Config["message"]),
 	}
 

--- a/website/content/usage/executors/kafka.md
+++ b/website/content/usage/executors/kafka.md
@@ -10,7 +10,7 @@ A basic Kafka executor that produces a message on a Kafka broker.
 Params
 
 ```
-brokerAddress: "IP:port" of the broker
+brokerAddress: Comma separated string containing "IP:port" of the brokers
 key:           The key of the message to produce
 message:       The body of the message to produce
 topic:         The Kafka topic for this message
@@ -22,7 +22,7 @@ Example
 ```json
 "executor": "kafka",
 "executor_config": {
-    "brokerAddress": "localhost:9092",
+    "brokerAddress": "localhost:9092,another.host:9092",
     "key": "My key",
     "message": "My message",
     "topic": "my_topic"


### PR DESCRIPTION
Kafka is supposed to be distributed, passing only broker can make messages fail if for some reason the broker is not up. In order to circumvent that issue, we can use multiple brokers. This can also improve the publishing rate.

Signed-off-by: Paulo Moura <itsme@paulomoura.com.pt>