### PR TITLE
Optionally set an alternative raftStore

### DIFF
--- a/dkron/options.go
+++ b/dkron/options.go
@@ -25,3 +25,9 @@ func WithStore(store Storage) AgentOption {
 		agent.Store = store
 	}
 }
+
+func WithRaftStore(raftStore RaftStore) AgentOption {
+	return func(agent *Agent) {
+		agent.raftStore = raftStore
+	}
+}


### PR DESCRIPTION
When used as a library, optionally allow setting a different raftStore.

Supersede #976 