### PR TITLE
add support for hash scheduling

### DIFF
--- a/dkron/job.go
+++ b/dkron/job.go
@@ -310,28 +310,28 @@ func (j *Job) GetTimeLocation() *time.Location {
 func (j *Job) scheduleHash() string {
 	spec := j.Schedule
 	if strings.Contains(spec, "H") && strings.Count(strings.TrimSpace(spec), " ") == 5 {
-		h := 0
+		hash := 0
 		for _, c := range j.Name {
-			h += int(c)
+			hash += int(c)
 		}
 		parts := strings.Split(spec, " ")
 		for index, part := range parts {
 			if strings.Contains(part, "H") {
 				// mods taken in accordance with https://dkron.io/docs/usage/cron-spec/#cron-expression-format
-				ph := h
+				partHash := hash
 				switch index {
 				case 2:
-					ph %= 24
+					partHash %= 24
 				case 3:
-					ph = (ph % 31) + 1
+					partHash = (partHash % 31) + 1
 				case 4:
-					ph = (ph % 12) + 1
+					partHash = (partHash % 12) + 1
 				case 5:
-					ph %= 7
+					partHash %= 7
 				default:
-					ph %= 60
+					partHash %= 60
 				}
-				parts[index] = strings.ReplaceAll(part, "H", strconv.Itoa(ph))
+				parts[index] = strings.ReplaceAll(part, "H", strconv.Itoa(partHash))
 			}
 		}
 		return strings.Join(parts, " ")

--- a/dkron/job.go
+++ b/dkron/job.go
@@ -306,17 +306,17 @@ func (j *Job) GetTimeLocation() *time.Location {
 }
 
 // scheduleHash replaces H in the cron spec by a value derived from job Name
-// such as "0 0 H * * *"
+// such as "0 0 ~ * * *"
 func (j *Job) scheduleHash() string {
 	spec := j.Schedule
-	if strings.Contains(spec, "H") && strings.Count(strings.TrimSpace(spec), " ") == 5 {
+	if strings.Contains(spec, "~") && strings.Count(strings.TrimSpace(spec), " ") == 5 {
 		hash := 0
 		for _, c := range j.Name {
 			hash += int(c)
 		}
 		parts := strings.Split(spec, " ")
 		for index, part := range parts {
-			if strings.Contains(part, "H") {
+			if strings.Contains(part, "~") {
 				// mods taken in accordance with https://dkron.io/docs/usage/cron-spec/#cron-expression-format
 				partHash := hash
 				switch index {
@@ -331,7 +331,7 @@ func (j *Job) scheduleHash() string {
 				default:
 					partHash %= 60
 				}
-				parts[index] = strings.ReplaceAll(part, "H", strconv.Itoa(partHash))
+				parts[index] = strings.ReplaceAll(part, "~", strconv.Itoa(partHash))
 			}
 		}
 		return strings.Join(parts, " ")

--- a/dkron/job_test.go
+++ b/dkron/job_test.go
@@ -192,6 +192,14 @@ func Test_isRunnable(t *testing.T) {
 	}
 }
 
+func Test_scheduleHash(t *testing.T) {
+	job := &Job{
+		Name:     "test_job",
+		Schedule: "0 0 ~ * * *",
+	}
+	assert.Equal(t, "0 0 18 * * *", job.scheduleHash())
+}
+
 type gRPCClientMock struct {
 }
 

--- a/dkron/job_test.go
+++ b/dkron/job_test.go
@@ -194,10 +194,14 @@ func Test_isRunnable(t *testing.T) {
 
 func Test_scheduleHash(t *testing.T) {
 	job := &Job{
-		Name:     "test_job",
-		Schedule: "0 0 ~ * * *",
+		Name: "test_job",
 	}
+	job.Schedule = "0 0 ~ * * *"
 	assert.Equal(t, "0 0 18 * * *", job.scheduleHash())
+	job.Schedule = "TZ=Europe/Madrid 0 0 1 * ~ *"
+	assert.Equal(t, "TZ=Europe/Madrid 0 0 1 * 7 *", job.scheduleHash())
+	job.Schedule = "TZ=Europe/Madrid @at something with ~"
+	assert.Equal(t, "TZ=Europe/Madrid @at something with ~", job.scheduleHash())
 }
 
 type gRPCClientMock struct {

--- a/dkron/scheduler.go
+++ b/dkron/scheduler.go
@@ -159,7 +159,7 @@ func (s *Scheduler) AddJob(job *Job) error {
 	// If Timezone is set on the job, and not explicitly in its schedule,
 	// AND its not a descriptor (that don't support timezones), add the
 	// timezone to the schedule so robfig/cron knows about it.
-	schedule := job.Schedule
+	schedule := job.scheduleHash()
 	if job.Timezone != "" &&
 		!strings.HasPrefix(schedule, "@") &&
 		!strings.HasPrefix(schedule, "TZ=") &&

--- a/website/docs/usage/cron-spec.md
+++ b/website/docs/usage/cron-spec.md
@@ -53,7 +53,7 @@ day-of-week blank.
 
 Tilde ( ~ )
 
-Tilde will be replaced by a numeric value valid for the range where it is used. It allows periodically scheduled tasks to produce even load on the system. For example, scheduling multiple hourly jobs to "0 H * * * *" rather than "0 0 * * * *" will run the jobs at different minutes of every hour. It can be thought of as a random value over a range, but it actually is a hash of the job name, not a random function, so that the value remains stable for any given job. 
+Tilde will be replaced by a numeric value valid for the range where it is used. It allows periodically scheduled tasks to produce even load on the system. For example, scheduling multiple hourly jobs to "0 ~ * * * *" rather than "0 0 * * * *" will run the jobs at different minutes of every hour. It can be thought of as a random value over a range, but it actually is a hash of the job name, not a random function, so that the value remains stable for any given job. 
 
 ### Predefined schedules
 

--- a/website/docs/usage/cron-spec.md
+++ b/website/docs/usage/cron-spec.md
@@ -9,12 +9,12 @@ A cron expression represents a set of times, using 6 space-separated fields.
 
 	Field name   | Mandatory? | Allowed values  | Allowed special characters
 	----------   | ---------- | --------------  | --------------------------
-	Seconds      | Yes        | 0-59            | * / , -
-	Minutes      | Yes        | 0-59            | * / , -
-	Hours        | Yes        | 0-23            | * / , -
-	Day of month | Yes        | 1-31            | * / , - ?
-	Month        | Yes        | 1-12 or JAN-DEC | * / , -
-	Day of week  | Yes        | 0-6 or SUN-SAT  | * / , - ?
+	Seconds      | Yes        | 0-59            | * / , - ~
+	Minutes      | Yes        | 0-59            | * / , - ~
+	Hours        | Yes        | 0-23            | * / , - ~
+	Day of month | Yes        | 1-31            | * / , - ? ~
+	Month        | Yes        | 1-12 or JAN-DEC | * / , - ~
+	Day of week  | Yes        | 0-6 or SUN-SAT  | * / , - ? ~
 
 Note: Month and Day-of-week field values are case insensitive.  "SUN", "Sun",
 and "sun" are equally accepted.
@@ -50,6 +50,10 @@ Question mark ( ? )
 
 Question mark may be used instead of '*' for leaving either day-of-month or
 day-of-week blank.
+
+Tilde ( ~ )
+
+Tilde will be replaced by a numeric value valid for the range where it is used. It allows periodically scheduled tasks to produce even load on the system. For example, scheduling multiple hourly jobs to "0 H * * * *" rather than "0 0 * * * *" will run the jobs at different minutes of every hour. It can be thought of as a random value over a range, but it actually is a hash of the job name, not a random function, so that the value remains stable for any given job. 
 
 ### Predefined schedules
 


### PR DESCRIPTION
This PR adds support for Jenkins-style hash schedule spec such as
```
0 0 H * * *
```

`H` is replaced by something derived from job name and moduled to its position within the spec (such as `H mod 60` for minutes but `H mod 24` for hour).

This allows for easily scheduling many daily jobs with same cron spec while still mildly balancing them throughout the day.

I tried to do it directly in the dkron `Scheduler` but it gets tricky due to the need of a second parameter that is not part of cron.Scheduler interface.

Also, the `hash` itself is actually just summing up the character values for simplification. It could be improved with an actual hashing method with less collisions and better distribution but in the end it would still use modullus 7, 12, 24, 60 causing many collisions.  
As this is not for security but only _mildly load balancing_, I left as is.

Let me have feedback!