### PR TITLE
Add logrus Hook to write logs to stderr and stdout based on log level

### DIFF
--- a/cmd/dkron.go
+++ b/cmd/dkron.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/distribworks/dkron/v3/dkron"
+	"github.com/distribworks/dkron/v3/logging"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -57,6 +58,9 @@ func initConfig() {
 	replacer := strings.NewReplacer("-", "_")
 	viper.SetEnvKeyReplacer(replacer)
 	viper.AutomaticEnv() // read in environment variables that match
+
+	// Add hook to set error logs to stderr and regular logs to stdout
+	logrus.AddHook(&logging.LogSplitter{})
 
 	err := viper.ReadInConfig() // Find and read the config file
 	if err != nil {             // Handle errors reading the config file

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,0 +1,32 @@
+package logging
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+type LogSplitter struct{}
+
+// Levels returns levels that are supported by the hook
+func (l *LogSplitter) Levels() []logrus.Level {
+	return []logrus.Level{logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel, logrus.WarnLevel, logrus.InfoLevel, logrus.DebugLevel, logrus.TraceLevel}
+}
+
+// Fire handles logging events based on log levels.
+func (l *LogSplitter) Fire(entry *logrus.Entry) error {
+	if entry == nil {
+		return fmt.Errorf("logrus entry is nil")
+	}
+
+	switch entry.Level {
+	case logrus.WarnLevel, logrus.DebugLevel, logrus.InfoLevel, logrus.TraceLevel:
+		entry.Logger.Out = os.Stdout
+	case logrus.ErrorLevel, logrus.PanicLevel, logrus.FatalLevel:
+		entry.Logger.Out = os.Stderr
+	default:
+		entry.Logger.Out = os.Stdout
+	}
+	return nil
+}


### PR DESCRIPTION
**Issue**

- Currently when we use DKRON as deployment in GCP k8s, the logs emitted by DKRON are by default captured as error logs by GCP Stackdriver. This is because by default logrus writes all logs to stderr. This gets misclassified by Stackdriver.

**Solution**

- Add a hook to logrus so that based on log levels they are written appropriately to the different output channels (stdout and stderr).