### PR TITLE
Do not retry job when unknown status

### DIFF
--- a/dkron/grpc_client.go
+++ b/dkron/grpc_client.go
@@ -426,7 +426,7 @@ func (grpcc *GRPCClient) AgentRun(addr string, job *proto.Job, execution *proto.
 		if err != nil {
 			// At this point the execution status will be unknown, set the FinishedAt time and an explanatory message
 			execution.FinishedAt = ptypes.TimestampNow()
-			execution.Output = []byte(err.Error())
+			execution.Output = []byte(ErrBrokenStream.Error() + ": " + err.Error())
 
 			grpcc.logger.WithError(err).Error(ErrBrokenStream)
 


### PR DESCRIPTION
When the gRPC stream is broken due to any network glitch, ExecutionDone is called with a failed state, this triggers the retry call, but the real status of the task is unknown.

This change disables retry when the reason for ExecutionDone is ErrBrokenStream.