### PR TITLE
add TLS options for kafka executor plugin

### DIFF
--- a/builtin/bins/dkron-executor-kafka/kafka.go
+++ b/builtin/bins/dkron-executor-kafka/kafka.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"errors"
 	"log"
 	"strings"
@@ -65,6 +66,15 @@ func (s *Kafka) ExecuteImpl(args *dktypes.ExecuteRequest) ([]byte, error) {
 	config.Producer.Retry.Max = 5
 	config.Producer.Return.Successes = true
 	config.Producer.Return.Errors = true
+
+	if args.Config["tlsEnable"] == "true" {
+		config.Net.TLS.Enable = true
+
+		config.Net.TLS.Config = &tls.Config{}
+		if args.Config["tlsInsecureSkipVerify"] == "true" {
+			config.Net.TLS.Config.InsecureSkipVerify = true
+		}
+	}
 
 	brokers := strings.Split(args.Config["brokerAddress"], ",")
 	producer, err := sarama.NewSyncProducer(brokers, config)

--- a/website/docs/usage/executors/kafka.md
+++ b/website/docs/usage/executors/kafka.md
@@ -7,11 +7,13 @@ A basic Kafka executor that produces a message on a Kafka broker.
 Params
 
 ```
-brokerAddress: Comma separated string containing "IP:port" of the brokers
-key:           The key of the message to produce
-message:       The body of the message to produce
-topic:         The Kafka topic for this message
-debug:         Turns on debugging output if not empty
+brokerAddress:          Comma separated string containing "IP:port" of the brokers
+key:                    The key of the message to produce
+message:                The body of the message to produce
+topic:                  The Kafka topic for this message
+tlsEnable:              Enables TLS if set to true. Optional
+tlsInsecureSkipVerify:  Disables verification of the remote SSL certificate's validity if set to true. Optional
+debug:                  Turns on debugging output if not empty
 ```
 
 Example


### PR DESCRIPTION
This PR adds TLS configurations for Kafka executor to enable users to communicate with Kafka clusters protected with encryption.