### PR TITLE
Move config init to agent command

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -29,6 +29,9 @@ var agentCmd = &cobra.Command{
 	Short: "Start a dkron agent",
 	Long: `Start a dkron agent that schedules jobs, listens for executions and runs executors.
 It also runs a web UI.`,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return initConfig()
+	},
 	// Run will execute the main functions of the agent command.
 	// This includes the main eventloop and starting the server if enabled.
 	//
@@ -42,8 +45,9 @@ It also runs a web UI.`,
 func init() {
 	dkronCmd.AddCommand(agentCmd)
 
+	agentCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file path")
 	agentCmd.Flags().AddFlagSet(dkron.ConfigFlagSet())
-	viper.BindPFlags(agentCmd.Flags())
+	_ = viper.BindPFlags(agentCmd.Flags())
 }
 
 func agentRun(args ...string) error {

--- a/cmd/dkron.go
+++ b/cmd/dkron.go
@@ -36,14 +36,8 @@ func Execute() {
 	}
 }
 
-func init() {
-	cobra.OnInitialize(initConfig)
-
-	dkronCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file path")
-}
-
 // initConfig reads in config file and ENV variables if set.
-func initConfig() {
+func initConfig() error {
 	if cfgFile != "" {
 		// Use config file from the flag.
 		viper.SetConfigFile(cfgFile)
@@ -68,7 +62,7 @@ func initConfig() {
 	}
 
 	if err := viper.Unmarshal(config); err != nil {
-		logrus.WithError(err).Fatal("config: Error unmarshalling config")
+		return fmt.Errorf("config: Error unmarshalling config: %s", err)
 	}
 
 	cliTags := viper.GetStringSlice("tag")
@@ -77,7 +71,7 @@ func initConfig() {
 	if len(cliTags) > 0 {
 		tags, err = UnmarshalTags(cliTags)
 		if err != nil {
-			logrus.WithError(err).Fatal("config: Error unmarshalling cli tags")
+			return fmt.Errorf("config: Error unmarshalling cli tags: %s", err)
 		}
 	} else {
 		tags = viper.GetStringMapString("tags")
@@ -86,4 +80,6 @@ func initConfig() {
 	config.Tags = tags
 
 	dkron.InitLogger(viper.GetString("log-level"), config.NodeName)
+
+	return nil
 }


### PR DESCRIPTION
Config init was being done on the root level command but only the agent command was using config values.

Now config init is done as pre-run of agent command only, getting rid of extra messages in other commands when the config was missing.

Happily fixes #1461 