### PR TITLE
Docs: Fix Prometheus metrics port

### DIFF
--- a/website/docs/usage/metrics.md
+++ b/website/docs/usage/metrics.md
@@ -32,7 +32,7 @@ scrape_configs:
   - job_name: "dkron_metrics"
     # metrics_path defaults to '/metrics'
     static_configs:
-      - targets: ["localhost:6080"]
+      - targets: ["localhost:8080"]
 ```
 
 ## Metrics


### PR DESCRIPTION
Seems like port 6080 is a typo in the docs, and it should be instead the default UI port 8080.

On a fresh Dkron installation I also don't see anything listening on 6080 port.

https://dkron.io/docs/usage/metrics