### PR TITLE
goreleaser: nice and forkable

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,9 @@ project_name: dkron
 release:
   prerelease: auto
 
+env:
+  - IMAGE_PREFIX={{ if index .Env "IMAGE_PREFIX"  }}{{ .Env.IMAGE_PREFIX }}{{ else }}dkron{{ end }}
+
 builds:
   - &xbuild
     main: .
@@ -107,7 +110,7 @@ snapshot:
 
 dockers:
   - image_templates:
-      - dkron/{{ .ProjectName }}:{{ .Version }}-amd64
+      - "{{ .Env.IMAGE_PREFIX }}/{{ .ProjectName }}:{{ .Version }}-amd64"
     dockerfile: Dockerfile.release
     use: buildx
     goos: linux
@@ -127,7 +130,7 @@ dockers:
       - --platform=linux/amd64
 
   - image_templates:
-      - dkron/{{ .ProjectName }}:{{ .Version }}-arm64
+      - "{{ .Env.IMAGE_PREFIX }}/{{ .ProjectName }}:{{ .Version }}-arm64"
     dockerfile: Dockerfile.release
     use: buildx
     goos: linux
@@ -137,7 +140,7 @@ dockers:
       - --platform=linux/arm64/v8
 
   - image_templates:
-      - dkron/{{ .ProjectName }}:{{ .Version }}-armv7
+      - "{{ .Env.IMAGE_PREFIX }}/{{ .ProjectName }}:{{ .Version }}-armv7"
     dockerfile: Dockerfile.release
     use: buildx
     goos: linux
@@ -148,7 +151,7 @@ dockers:
       - --platform=linux/arm/v7
 
   - image_templates:
-      - dkron/{{ .ProjectName }}:{{ .Version }}-light-amd64
+      - "{{ .Env.IMAGE_PREFIX }}/{{ .ProjectName }}:{{ .Version }}-light-amd64"
     dockerfile: Dockerfile.release
     use: buildx
     goos: linux
@@ -159,7 +162,7 @@ dockers:
       - --platform=linux/amd64
 
   - image_templates:
-      - dkron/{{ .ProjectName }}:{{ .Version }}-light-arm64
+      - "{{ .Env.IMAGE_PREFIX }}/{{ .ProjectName }}:{{ .Version }}-light-arm64"
     dockerfile: Dockerfile.release
     use: buildx
     goos: linux
@@ -169,7 +172,7 @@ dockers:
       - --platform=linux/arm64/v8
 
   - image_templates:
-      - dkron/{{ .ProjectName }}:{{ .Version }}-light-armv7
+      - "{{ .Env.IMAGE_PREFIX }}/{{ .ProjectName }}:{{ .Version }}-light-armv7"
     dockerfile: Dockerfile.release
     use: buildx
     goos: linux
@@ -180,23 +183,29 @@ dockers:
       - --platform=linux/arm/v7
 
 docker_manifests:
-  - name_template: dkron/{{ .ProjectName }}:{{ .Version }}
+  - name_template: "{{ .Env.IMAGE_PREFIX }}/{{ .ProjectName }}:{{ .Version }}"
     image_templates:
-      - dkron/{{ .ProjectName }}:{{ .Version }}-amd64
-      - dkron/{{ .ProjectName }}:{{ .Version }}-arm64
-      - dkron/{{ .ProjectName }}:{{ .Version }}-armv7
+      - "{{ .Env.IMAGE_PREFIX }}/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "{{ .Env.IMAGE_PREFIX }}/{{ .ProjectName }}:{{ .Version }}-arm64"
+      - "{{ .Env.IMAGE_PREFIX }}/{{ .ProjectName }}:{{ .Version }}-armv7"
 
-  - name_template: dkron/{{ .ProjectName }}:latest
+  - name_template: "{{ .Env.IMAGE_PREFIX }}/{{ .ProjectName }}:latest"
     image_templates:
-    - dkron/{{ .ProjectName }}:{{ .Version }}-amd64
-    - dkron/{{ .ProjectName }}:{{ .Version }}-arm64
-    - dkron/{{ .ProjectName }}:{{ .Version }}-armv7
+    - "{{ .Env.IMAGE_PREFIX }}/{{ .ProjectName }}:{{ .Version }}-amd64"
+    - "{{ .Env.IMAGE_PREFIX }}/{{ .ProjectName }}:{{ .Version }}-arm64"
+    - "{{ .Env.IMAGE_PREFIX }}/{{ .ProjectName }}:{{ .Version }}-armv7"
 
-  - name_template: dkron/{{ .ProjectName }}:{{ .Version }}-light
+  - name_template: "{{ .Env.IMAGE_PREFIX }}/{{ .ProjectName }}:{{ .Version }}-light"
     image_templates:
-    - dkron/{{ .ProjectName }}:{{ .Version }}-light-amd64
-    - dkron/{{ .ProjectName }}:{{ .Version }}-light-arm64
-    - dkron/{{ .ProjectName }}:{{ .Version }}-light-armv7
+    - "{{ .Env.IMAGE_PREFIX }}/{{ .ProjectName }}:{{ .Version }}-light-amd64"
+    - "{{ .Env.IMAGE_PREFIX }}/{{ .ProjectName }}:{{ .Version }}-light-arm64"
+    - "{{ .Env.IMAGE_PREFIX }}/{{ .ProjectName }}:{{ .Version }}-light-armv7"
+
+  - name_template: "{{ .Env.IMAGE_PREFIX }}/{{ .ProjectName }}:light"
+    image_templates:
+    - "{{ .Env.IMAGE_PREFIX }}/{{ .ProjectName }}:{{ .Version }}-light-amd64"
+    - "{{ .Env.IMAGE_PREFIX }}/{{ .ProjectName }}:{{ .Version }}-light-arm64"
+    - "{{ .Env.IMAGE_PREFIX }}/{{ .ProjectName }}:{{ .Version }}-light-armv7"
 
 changelog:
   sort: asc


### PR DESCRIPTION
Allow container images prefix to be changed more easily, for contributor local testing or forks.

By setting variable in shell:

```
IMAGE_PREFIX=someotherOrg goreleaser ...
```

Or modifying one single line (causing less conflicts/diffs to review)

Also added a "latest" for the light version