### PR TITLE
Fixes: upgrade docker base image to fix error: 0.524 go: go.mod requi…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22
+FROM golang:1.23.1
 LABEL maintainer="Victor Castell <0x@vcastellm.xyz>"
 
 EXPOSE 8080 8946


### PR DESCRIPTION
Upgrade docker base image when execute ```docker-compose up -d``` in main branch.
error message:
```
 => ERROR [dkron 6/8] RUN go mod download                                                                      1.8s ------
 > [dkron 6/8] RUN go mod download:
0.524 go: go.mod requires go >= 1.23.1 (running go 1.22.9; GOTOOLCHAIN=local)
------
failed to solve: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```