### PR TITLE
Prevent calling output on an undefined record

### DIFF
--- a/ui/src/executions/BusyList.tsx
+++ b/ui/src/executions/BusyList.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { List, Datagrid, TextField, DateField } from 'react-admin';
 
 export const OutputPanel = ({ id, record, resource }: any) => {
-    return (<div className="execution-output">{record.output || "Empty output"}</div>);
+    return (<div className="execution-output">{record?.output || "Empty output"}</div>);
 };
 
 export const BusyList = (props: any) => (


### PR DESCRIPTION
Hello

I upgraded to Dkron 4.0.0 for Windows AMD64 and the UI crashes for Busy job when I try to expand the output. It used to work on version 3.7 for the same shell command line.

https://github.com/distribworks/dkron/blob/e232733f0d13d22e13031e6f3ebf2a34d3e33a5a/ui/src/executions/BusyList.tsx#L5

A quick fix would be

```tsx
record?.output
```

![image](https://github.com/user-attachments/assets/3a565ed6-c505-459a-bb43-52fd5c8a759b)


