### PR TITLE
Fix help message for remove-peer raft command

### DIFF
--- a/cmd/raft.go
+++ b/cmd/raft.go
@@ -59,7 +59,7 @@ var peerID string
 
 var raftRemovePeerCmd = &cobra.Command{
 	Use:   "remove-peer",
-	Short: "Command to list raft peers",
+	Short: "Command to remove a peer from raft",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log := logrus.NewEntry(logrus.New())


### PR DESCRIPTION
The current message was duplicated from the list-peers raft command.