### PR TITLE
fix: This fixes jobs child processes

### DIFF
--- a/plugin/shell/shell_unix.go
+++ b/plugin/shell/shell_unix.go
@@ -30,11 +30,15 @@ func setCmdAttr(cmd *exec.Cmd, config map[string]string) error {
 		} else {
 			gid, _ = strconv.Atoi(u.Gid)
 		}
-		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 		cmd.SysProcAttr.Credential = &syscall.Credential{
 			Uid: uint32(uid),
 			Gid: uint32(gid),
 		}
+	}
+
+	jobTimeout := config["timeout"]
+	if jobTimeout != "" {
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	}
 	return nil
 }


### PR DESCRIPTION
Jobs where getting stuck in busy because for some reason the mechanism for kiling the jos on timeout was loosing track of the process at SO level.

fixes #1483 