### PR TITLE
fix: RabbitMQ executor configuration/payload validation

### DIFF
--- a/builtin/bins/dkron-executor-rabbitmq/rabbitmq.go
+++ b/builtin/bins/dkron-executor-rabbitmq/rabbitmq.go
@@ -7,6 +7,7 @@ import (
 
 	dkplugin "github.com/distribworks/dkron/v4/plugin"
 	dktypes "github.com/distribworks/dkron/v4/types"
+	log "github.com/sirupsen/logrus"
 	"github.com/streadway/amqp"
 )
 
@@ -68,9 +69,10 @@ func (r *RabbitMQ) ExecuteImpl(args *dktypes.ExecuteRequest, cb dkplugin.StatusH
 	defer func(conn *amqp.Connection) {
 		err := conn.Close()
 		if err != nil {
-			// DO NOTHING
+			log.Error("Failed to close amqp connection", log.WithError(err))
 		}
 	}(conn)
+
 	ch, err := conn.Channel()
 	if err != nil {
 		return nil, err
@@ -78,7 +80,7 @@ func (r *RabbitMQ) ExecuteImpl(args *dktypes.ExecuteRequest, cb dkplugin.StatusH
 	defer func(ch *amqp.Channel) {
 		err := ch.Close()
 		if err != nil {
-			// DO NOTHING
+			log.Error("Failed to close channel", log.WithError(err))
 		}
 	}(ch)
 

--- a/builtin/bins/dkron-executor-rabbitmq/rabbitmq.go
+++ b/builtin/bins/dkron-executor-rabbitmq/rabbitmq.go
@@ -11,8 +11,7 @@ import (
 )
 
 // RabbitMQ process publish rabbitmq message when Execute method is called.
-type RabbitMQ struct {
-}
+type RabbitMQ struct{}
 
 // Execute method of the plugin
 // "executor": "rabbitmq",
@@ -28,6 +27,7 @@ type RabbitMQ struct {
 //			"message.delivery_mode": "2",
 //			"message.messageId": "4373732772",
 //			"message.body": "{\"key\":\"value\"}"
+//			"message.base64Body": "base64encodedBody"
 //	}
 func (r *RabbitMQ) Execute(args *dktypes.ExecuteRequest, cb dkplugin.StatusHelper) (*dktypes.ExecuteResponse, error) {
 	out, err := r.ExecuteImpl(args, cb)
@@ -56,8 +56,8 @@ func (r *RabbitMQ) ExecuteImpl(args *dktypes.ExecuteRequest, cb dkplugin.StatusH
 		return nil, errors.New("RabbitMQ queue name is empty")
 	}
 
-	if cfg["message.body"] != "" && args.Config["message.base64"] != "" {
-		return nil, errors.New("RabbitMQ message.body and message.base64 are both set")
+	if cfg["message.body"] != "" && cfg["message.base64Body"] != "" {
+		return nil, errors.New("RabbitMQ message.body and message.base64Body are both set")
 	}
 
 	// establish connection
@@ -83,7 +83,7 @@ func (r *RabbitMQ) ExecuteImpl(args *dktypes.ExecuteRequest, cb dkplugin.StatusH
 	}(ch)
 
 	// create queue if necessary
-	if err := createQueueIfNecessary(args.Config, queueName, ch); err != nil {
+	if err := createQueueIfNecessary(cfg, queueName, ch); err != nil {
 		return nil, err
 	}
 

--- a/builtin/bins/dkron-executor-rabbitmq/rabbitmq_test.go
+++ b/builtin/bins/dkron-executor-rabbitmq/rabbitmq_test.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"testing"
 
 	dktypes "github.com/distribworks/dkron/v4/types"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPublishExecute(t *testing.T) {
@@ -17,10 +17,71 @@ func TestPublishExecute(t *testing.T) {
 		},
 	}
 	rabbitmq := &RabbitMQ{}
-	output, err := rabbitmq.Execute(pa, nil)
-	fmt.Println(string(output.Output))
-	fmt.Println(err)
+	_, err := rabbitmq.Execute(pa, nil)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestPublishExecute_V2(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        *dktypes.ExecuteRequest
+		expectedErr string
+	}{
+
+		{
+			name: "No url provided",
+			args: &dktypes.ExecuteRequest{
+				Config: map[string]string{},
+			},
+			expectedErr: "RabbitMQ url is empty",
+		},
+		{
+			name: "No queue provided",
+			args: &dktypes.ExecuteRequest{
+				Config: map[string]string{
+					"url": "amqp://guest:guest@localhost:5672",
+				},
+			},
+			expectedErr: "RabbitMQ queue name is empty",
+		},
+		{
+			name: "Body and base64Body provided",
+			args: &dktypes.ExecuteRequest{
+				Config: map[string]string{
+					"url":                "amqp://guest:guest@localhost:5672",
+					"queue.name":         "test",
+					"message.body":       "body",
+					"message.base64Body": "base64",
+				},
+			},
+			expectedErr: "RabbitMQ message.body and message.base64Body are both set",
+		},
+		{
+			name: "All good",
+			args: &dktypes.ExecuteRequest{
+				Config: map[string]string{
+					"url":          "amqp://guest:guest@localhost:5672",
+					"message.body": "{\"key\":\"value\"}",
+					"queue.name":   "test",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			// Spin up the rabbitmq server
+			// todo setup a consumer and check if the message is sent
+			r := &RabbitMQ{}
+			output, err := r.Execute(tt.args, nil)
+			assert.NoError(t, err)
+			if tt.expectedErr != "" {
+				assert.Equal(t, tt.expectedErr, output.Error)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Seems like there was a discrepancy in the RabbitMQ executor payload validation and actual implementation for publishing base64 encoded bodies.

Validation prevented both the unencoded body and base64 encoded body to be set, but in when publishing, it checked the wrong attribute. This could allow both the `message.body` and `"message.base64Body"` to be set and still publish the message.

Also: 
- Added logs to RabbitMQ executor
- Added test cases for configuration validation