### PR TITLE
fix: Executors documentation 

### DIFF
--- a/website/docs/usage/executors/grpc.md
+++ b/website/docs/usage/executors/grpc.md
@@ -2,9 +2,9 @@
 
 GRPC executor can send a request to a GRPC Server
 
-
 ## Requirements
-In order to serialize protobufs the server need's to have the reflection service active.
+
+In order to serialize protobufs, the server needs to have the reflection service active.
 Without that we cannot get proto descriptors required for serialization.
 
 ## Configuration
@@ -18,16 +18,16 @@ Params:
 "expectCode": Optional, One of https://grpc.github.io/grpc/core/md_doc_statuscodes.html
 ```
 
-Example
+Example:
 
 ```json
 {
   "executor": "http",
   "executor_config": {
-      "url": "127.0.0.1:9000/test.TestService/Test",
-      "body": "{\"key\": \"value\"}",
-      "timeout": "30",
-      "expectCode": "0"
+    "url": "127.0.0.1:9000/test.TestService/Test",
+    "body": "{\"key\": \"value\"}",
+    "timeout": "30",
+    "expectCode": "0"
   }
 }
 ```

--- a/website/docs/usage/executors/http.md
+++ b/website/docs/usage/executors/http.md
@@ -21,20 +21,20 @@ tlsCertificateKeyFile: Path to the PEM file containing the client certificate pr
 tlsRootCAsFile:        Path to the PEM file containing certificates to use as root CAs. Optional.
 ```
 
-Example
+Example:
 
 ```json
 {
   "executor": "http",
   "executor_config": {
-      "method": "GET",
-      "url": "http://example.com",
-      "headers": "[]",
-      "body": "",
-      "timeout": "30",
-      "expectCode": "200",
-      "expectBody": "",
-      "debug": "true"
+    "method": "GET",
+    "url": "http://example.com",
+    "headers": "[]",
+    "body": "",
+    "timeout": "30",
+    "expectCode": "200",
+    "expectBody": "",
+    "debug": "true"
   }
 }
 ```

--- a/website/docs/usage/executors/kafka.md
+++ b/website/docs/usage/executors/kafka.md
@@ -4,7 +4,7 @@ A basic Kafka executor that produces a message on a Kafka broker.
 
 ## Configuration
 
-Params
+Params:
 
 ```
 brokerAddress:          Comma separated string containing "IP:port" of the brokers
@@ -19,14 +19,16 @@ saslMechanism:          The SASL SCRAM mechanism to use, either "sha256" or "sha
 debug:                  Turns on debugging output if not empty
 ```
 
-Example
+Example:
 
 ```json
-"executor": "kafka",
-"executor_config": {
+{
+  "executor": "kafka",
+  "executor_config": {
     "brokerAddress": "localhost:9092,another.host:9092",
     "key": "My key",
     "message": "My message",
     "topic": "my_topic"
+  }
 }
 ```

--- a/website/docs/usage/executors/nats.md
+++ b/website/docs/usage/executors/nats.md
@@ -6,7 +6,7 @@ Currently, only username/password authentication is supported.
 
 ## Configuration
 
-Params
+Params:
 
 ```
 url:      Comma separated list of NATS server URLs
@@ -17,16 +17,17 @@ password: password for authentication
 debug:    If not empty, turns on debugging. Will log the NATS specific job config and the request sent.
 ```
 
-Example
+Example:
 
 ```json
 {
-   "executor": "nats",
-   "executor_config": {
-       "url": "tls://nats.demo.io:4443", 
-       "message": "the message",
-       "subject": "myfavoritesubject",
-       "userName":"someusername",
-       "password":"somepassword"
+  "executor": "nats",
+  "executor_config": {
+    "url": "tls://nats.demo.io:4443",
+    "message": "the message",
+    "subject": "myfavoritesubject",
+    "userName": "someusername",
+    "password": "somepassword"
+  }
 }
 ```

--- a/website/docs/usage/executors/rabbitmq.md
+++ b/website/docs/usage/executors/rabbitmq.md
@@ -1,0 +1,40 @@
+# RabbitMQ Executor
+
+A basic RabbitMQ executor that produces a message on a RabbitMQ server/cluster.
+
+## Configuration
+
+Params
+
+```
+url:                         URL of the RabbitMQ server/cluster with VHost. Example: amqp://guest:guest@localhost:5672/
+queue.name:                  The name of the queue to publish the message to. Required
+queue.durable:               Whether the queue is durable or not. Optional, defaults to false
+queue.auto_delete:           Whether the queue is auto-deleted after publishing the message. Optional, defaults to false
+queue.exclusive:             Whether the queue is exclusive or not. Optional, defaults to false
+message.content_type:        The content type of the message
+message.delivery_mode:       Message delivery mode. 1 for non-persistent, 2 for persistent. Optional, defaults to 0
+message.messageId:           The message ID
+message.body:                The actual message body in desired format that will be sent to the queue
+message.base64:              Encoded message body in base64 format. Optional, but should not be set if message.body is set.
+```
+
+Example:
+
+```json
+{
+  "executor": "rabbitmq",
+  "executor_config": {
+    "url": "amqp://guest:guest@localhost:5672/",
+    "queue.name": "test",
+    "queue.create": "true",
+    "queue.durable": "true",
+    "queue.auto_delete": "false",
+    "queue.exclusive": "false",
+    "message.content_type": "application/json",
+    "message.delivery_mode": "2",
+    "message.messageId": "4373732772",
+    "message.body": "{\"key\":\"value\"}"
+  }
+}
+```


### PR DESCRIPTION
I did a couple of things: 

1. Fixed JSON formatting in NATS and Kafka executor docs 
2. Fixed a typo
3. Executor docs are a bit more uniform 
4. Added missing RabbitMQ Executor documentation.