### PR TITLE
Fix: keep the existing dependent_jobs value on updating an existing job

### DIFF
--- a/dkron/fsm.go
+++ b/dkron/fsm.go
@@ -82,7 +82,7 @@ func (d *dkronFSM) applySetJob(buf []byte) interface{} {
 		return err
 	}
 	job := NewJobFromProto(&pj, d.logger)
-	if err := d.store.SetJob(job, false); err != nil {
+	if err := d.store.SetJob(job, true); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
## Proposed changes

Instructs the store to include existing dependent_jobs on job update.  
Currently the dependent_jobs slice gets reset to nil on updating an existing job, this breaks the job chaining feature.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
