### PR TITLE
fix: autogen ci issues

### DIFF
--- a/.github/workflows/autogen.yaml
+++ b/.github/workflows/autogen.yaml
@@ -23,6 +23,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        if: github.event_name == 'pull_request'
+        with:
+          ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Checkout (default)
+        uses: actions/checkout@v4
+        if: github.event_name != 'pull_request'
         with:
           ref: ${{ github.head_ref }}
 
@@ -40,6 +48,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        if: github.event_name == 'pull_request'
+        with:
+          ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Checkout (default)
+        uses: actions/checkout@v4
+        if: github.event_name != 'pull_request'
         with:
           ref: ${{ github.head_ref }}
 
@@ -60,7 +76,7 @@ jobs:
           commit_message: "[Autogen] Generated client from OpenAPI spec"
 
       - name: Create a pull request
-        if : github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/autogen.yaml
+++ b/.github/workflows/autogen.yaml
@@ -34,10 +34,14 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Swagger Editor Validator
-        uses: swaggerexpert/swagger-editor-validate@v1
-        with:
-          definition-file: ./website/static/openapi/openapi.yaml
+      - name: Set up node
+        uses: actions/setup-node@v4
+
+      - name: Install Redocly CLI
+        run: npm install -g @redocly/cli@latest
+
+      - name: Run linting
+        run: redocly lint ./website/static/openapi/openapi.yaml --format=github-actions
 
   generate:
     name: Generate the OpenAPI client

--- a/dkron/api_test.go
+++ b/dkron/api_test.go
@@ -67,17 +67,14 @@ func TestAPIJobCreateUpdate(t *testing.T) {
 	}`)
 
 	resp, err := http.Post(baseURL+"/jobs", "encoding/json", bytes.NewBuffer(jsonStr))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	body, _ := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
 	var origJob Job
-	if err := json.Unmarshal(body, &origJob); err != nil {
-		t.Fatal(err)
-	}
+	err = json.Unmarshal(body, &origJob)
+	require.NoError(t, err)
 
 	jsonStr1 := []byte(`{
 		"name": "test_job",


### PR DESCRIPTION
## Proposed changes

- Fix repository checkout - chechks out the PR repository instead of source
- Fix OpenAPI validation - use Redocly CLI instead of Swagger Validator, as it does not support OpenAPI 3.1 validation. The `editor-next` version does, but the action seems not to have a compatible API. 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
