### PR TITLE
fix: comment out process metrics collection for debugging

### DIFF
--- a/plugin/shell/shell.go
+++ b/plugin/shell/shell.go
@@ -132,7 +132,8 @@ func (s *Shell) ExecuteImpl(args *dktypes.ExecuteRequest, cb dkplugin.StatusHelp
 
 	quit := make(chan int)
 
-	go CollectProcessMetrics(args.JobName, cmd.Process.Pid, quit)
+	// FIXME: Debug metrics collection
+	// go CollectProcessMetrics(args.JobName, cmd.Process.Pid, quit)
 
 	err = cmd.Wait()
 	quit <- cmd.ProcessState.ExitCode()


### PR DESCRIPTION
This pull request makes a minor change to the `plugin/shell/shell.go` file by commenting out the invocation of the process metrics collection function in the `ExecuteImpl` method. This appears to be a temporary measure for debugging purposes.

* Commented out the call to `CollectProcessMetrics` to disable process metrics collection during command execution, with a FIXME note for debugging.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)