### PR TITLE
fix: enable cmd.Wait in shell plugin execution

### DIFF
--- a/plugin/shell/shell.go
+++ b/plugin/shell/shell.go
@@ -135,7 +135,11 @@ func (s *Shell) ExecuteImpl(args *dktypes.ExecuteRequest, cb dkplugin.StatusHelp
 
 	// go CollectProcessMetrics(args.JobName, cmd.Process.Pid, quit)
 
-	// err = cmd.Wait()
+	err = cmd.Wait()
+	if err != nil {
+		log.Printf("shell: Job '%s' execution failed with error: %v", command, err)
+	}
+
 	// quit <- cmd.ProcessState.ExitCode()
 	// close(quit) // exit metric refresh goroutine after job is finished
 


### PR DESCRIPTION
This pull request makes a small but important change to the `ExecuteImpl` function in `plugin/shell/shell.go`. The change ensures that errors from the executed shell command are no longer ignored and are now logged, improving visibility into job failures. 

* Error handling improvement: The result of `cmd.Wait()` is now assigned to `err`, and any error encountered during command execution is logged with the job name and error details.
